### PR TITLE
fix: mangum/router connectivity

### DIFF
--- a/server/backend/api/app/routers/router_application.py
+++ b/server/backend/api/app/routers/router_application.py
@@ -16,6 +16,11 @@ router = APIRouter()
     response_model=List[schemas.FamApplication],
     status_code=200
 )
+@router.get(
+    "",
+    response_model=List[schemas.FamApplication],
+    status_code=200
+)
 def get_fam_applications(response: Response,
                          db: Session = Depends(dependencies.get_db)):
     """


### PR DESCRIPTION
* trying additional decorators based on this idea:

https://stackoverflow.com/questions/71984078/fastapi-application-as-an-aws-lambda-function-url-gets-stuck-in-eternal-redirect