### PR TITLE
Feat/260 serverjs envjs fix web client id dev

### DIFF
--- a/.github/workflows/reusable_terraform_frontend.yml
+++ b/.github/workflows/reusable_terraform_frontend.yml
@@ -77,6 +77,12 @@ jobs:
             ${{ steps.terragrunt-server-output.outputs.stdout }}
           write-mode: overwrite
 
+      - name: Append Additional Environment Settings.
+        working-directory: infrastructure/frontend/dist
+        run: |
+          echo "," >> env.json
+          echo '"env": "${{ inputs.environment_name }}"' >> env.json
+
       - id: terragrunt-server-output-test
         working-directory: infrastructure/frontend/dist
         name: Terragrunt Server Output Verify

--- a/.github/workflows/reusable_terraform_frontend.yml
+++ b/.github/workflows/reusable_terraform_frontend.yml
@@ -69,10 +69,10 @@ jobs:
           EOF
           terragrunt run-all output -json
 
-      - name: Create server.json file
+      - name: Create env.json file
         uses: DamianReeves/write-file-action@master
         with:
-          path: infrastructure/frontend/dist/server.json
+          path: infrastructure/frontend/dist/env.json
           contents: |
             ${{ steps.terragrunt-server-output.outputs.stdout }}
           write-mode: overwrite
@@ -81,9 +81,9 @@ jobs:
         working-directory: infrastructure/frontend/dist
         name: Terragrunt Server Output Verify
         run: |
-          echo "printing out contents of server.json"
+          echo "printing out contents of env.json"
           echo "===================================="
-          cat server.json
+          cat env.json
           echo "===================================="
 
       - name: Terragrunt ${{ inputs.tf_subcommand }}

--- a/infrastructure/server/outputs.tf
+++ b/infrastructure/server/outputs.tf
@@ -1,4 +1,4 @@
-output "VUE_APP_API_GW_BASE_URL" {
+output "fam_api_base_url" {
   description = "Base URL for API Gateway stage."
   value       = aws_api_gateway_deployment.fam_api_gateway_deployment.invoke_url
 }
@@ -17,7 +17,7 @@ output "fam_user_pool_id" {
 
 output "fam_console_web_client_id" {
   description = "Web client ID for the FAM OIDC client for front end connection"
-  value       = aws_cognito_user_pool_client.fom_public_oidc_client.id
+  value       = aws_cognito_user_pool_client.fam_console_oidc_client.id
 }
 
 output "fam_cognito_domain" {


### PR DESCRIPTION
**Not Finished**
Still need:
**!** Add **additional** environment settings: OUTPUT "**{env: dev/test/prod}**"
**!** How to **SET** two CALLBACK_URL **into Cognito** (from frontend CloudFront/S3) then **OUTPUT** to **env.json** as callback urls for frontend environment settings (used by **Amplify**). <-- This will come as separate change.

**Already done**:
- Rename server.json to **env.json**.
- Fix '**fam_console_web_client_id**' output. 
- Rename 'VUE_APP_API_GW_BASE_URL' to '**fam_api_base_url**' output key.
