### PR TITLE
Feat/359 auth filter fam applications

### DIFF
--- a/server/auth_function/test/database_setup_fixtures.py
+++ b/server/auth_function/test/database_setup_fixtures.py
@@ -151,7 +151,7 @@ def create_test_fam_role(auth_object, test_role_name):
         ('{}',
         'just for testing',
         (select application_id from app_fam.fam_application
-            where application_name = 'fam'),
+            where application_name = 'FAM'),
         'C',
         CURRENT_USER,
         CURRENT_USER)
@@ -229,7 +229,7 @@ def create_test_fam_cognito_client(auth_object):
     values(
         '{}',
         (select application_id from app_fam.fam_application
-            where application_name = 'fam'),
+            where application_name = 'FAM'),
         CURRENT_USER,
         CURRENT_USER)
     """
@@ -300,7 +300,7 @@ def get_insert_role_sql(role_name, role_type, parent_role_id=None):
         ('{role_name}',
         'just for testing',
         (select application_id from app_fam.fam_application
-            where application_name = 'fam'),
+            where application_name = 'FAM'),
         '{role_type}',
         CURRENT_USER,
         CURRENT_USER {parent_value})

--- a/server/backend/api/app/crud/crud_application.py
+++ b/server/backend/api/app/crud/crud_application.py
@@ -40,16 +40,19 @@ def get_applications_by_granted_apps(db: Session, access_roles: List[str]) -> Li
     """
     LOGGER.debug(f"Running get_applications_by_granted_app, access_roles: {access_roles}")
 
-    # Convert to Upper Case.
-    REPLACE_STR_KEY = "_ACCESS_ADMIN"
-    upper_app_names = crud_utils.replace_str_list(crud_utils.to_upper(access_roles), REPLACE_STR_KEY, "")
-    
-    LOGGER.debug(f"Running db lookup for app name: {upper_app_names}")
+    # Filter out others and only contains Access Admin roles
+    ACCESS_ADMIN_ROLE_SUFFIX = "_ACCESS_ADMIN"
+    admin_access_roles = filter(
+        lambda x: x.endswith(ACCESS_ADMIN_ROLE_SUFFIX), access_roles
+    )
+    app_names = crud_utils.replace_str_list(admin_access_roles, ACCESS_ADMIN_ROLE_SUFFIX, "")
 
-    fam_apps = ( 
+    LOGGER.debug(f"Running db lookup for app name: {app_names}")
+
+    fam_apps = (
         db.query(models.FamApplication)
         .filter(
-            func.upper(models.FamApplication.application_name).in_(upper_app_names)
+            models.FamApplication.application_name.in_(app_names)
         )
         .distinct(models.FamApplication.application_name)
         .all()

--- a/server/backend/api/app/crud/crud_application.py
+++ b/server/backend/api/app/crud/crud_application.py
@@ -31,7 +31,7 @@ def get_applications(db: Session):
     return fam_apps
 
 
-def get_applications_by_granted_apps(db: Session, access_roles: List[str]) -> models.FamApplication:
+def get_applications_by_granted_apps(db: Session, access_roles: List[str]) -> List[models.FamApplication]:
     """ Get applications based on access roles that are associated with.
         Note, this isn't to find the applications that the 'roles belong to'.
 

--- a/server/backend/api/app/crud/crud_utils.py
+++ b/server/backend/api/app/crud/crud_utils.py
@@ -13,11 +13,11 @@ from sqlalchemy.orm import Session
 LOGGER = logging.getLogger(__name__)
 
 def to_upper(elements: List[str]) -> List[str]:
-    return [x.upper() for x in elements]
+    return [x.upper() for x in elements] if elements else None
 
 
 def replace_str_list(elements: List[str], str_to_replace: str, replace_with: str) -> List[str]:
-    return list(map(lambda r: r.replace(str_to_replace, replace_with), elements))
+    return list(map(lambda r: r.replace(str_to_replace, replace_with), elements)) if elements else None
 
 
 def get_primary_key(model: models) -> str:

--- a/server/backend/api/app/crud/crud_utils.py
+++ b/server/backend/api/app/crud/crud_utils.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 import sqlalchemy
 from api.app.models import model as models
@@ -10,6 +11,13 @@ from sqlalchemy.orm import Session
 # from typing import
 
 LOGGER = logging.getLogger(__name__)
+
+def to_upper(elements: List[str]) -> List[str]:
+    return [x.upper() for x in elements]
+
+
+def replace_str_list(elements: List[str], str_to_replace: str, replace_with: str) -> List[str]:
+    return list(map(lambda r: r.replace(str_to_replace, replace_with), elements))
 
 
 def get_primary_key(model: models) -> str:

--- a/server/backend/api/app/jwt_validation.py
+++ b/server/backend/api/app/jwt_validation.py
@@ -215,13 +215,18 @@ def authorize_by_app_id(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    required_group = f"{application.application_name.upper()}_ACCESS_ADMIN"
-    groups = claims[JWT_GROUPS_KEY]
+    required_role = f"{application.application_name.upper()}_ACCESS_ADMIN"
+    access_roles = get_access_roles(claims)
 
-    if required_group not in groups:
+    if required_role not in access_roles:
         raise HTTPException(
             status_code=403,
             detail={'code': ERROR_PERMISSION_REQUIRED,
-                    'description': f'Operation requires role {required_group}'},
+                    'description': f'Operation requires role {required_role}'},
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+
+def get_access_roles(claims: dict = Depends(authorize)):
+    groups = claims[JWT_GROUPS_KEY]
+    return groups

--- a/server/backend/api/app/models/model.py
+++ b/server/backend/api/app/models/model.py
@@ -84,6 +84,9 @@ class FamApplication(Base):
         },
     )
 
+    def __repr__(self):
+        return f'FamApplication({self.application_id}, {self.application_name}, {self.app_environment})'
+
 
 class FamForestClient(Base):
     __tablename__ = "fam_forest_client"

--- a/server/backend/api/app/routers/router_application.py
+++ b/server/backend/api/app/routers/router_application.py
@@ -16,14 +16,14 @@ router = APIRouter()
 def get_applications(
     response: Response,
     db: Session = Depends(database.get_db),
-    token_claims: dict = Depends(jwt_validation.authorize)
+    access_roles: dict = Depends(jwt_validation.get_access_roles)
 ):
 
     """
     List of different applications that are administered by FAM
     """
     LOGGER.debug(f"running router ... {db}")
-    query_data = crud_application.get_applications(db)
+    query_data = crud_application.get_applications_by_granted_apps(db, access_roles)
     if len(query_data) == 0:
         response.status_code = 204
     return query_data

--- a/server/backend/tests/crud/test_crud_application.py
+++ b/server/backend/tests/crud/test_crud_application.py
@@ -323,3 +323,67 @@ def test_get_application_role_assignments_wrong_application(
     )
     LOGGER.debug(f"role_assignments: {role_assignments}")
     assert not role_assignments
+
+
+def test_get_applications_by_granted_apps(
+    dbsession_different_envs_apps: sqlalchemy.orm.session.Session
+):
+    # This db session contains apps: ['fam', 'fom_dev', 'fom_test, 'fom_prod'] setup.
+    db = dbsession_different_envs_apps
+
+    # Testing 'get_applications_by_granted_apps' with Accss Roles: FAM_ACCESS_ADMIN only
+    access_roles_fam_only = ["FAM_ACCESS_ADMIN"]
+    LOGGER.debug(f"Testing 'get_applications_by_granted_apps' with Accss Roles: {access_roles_fam_only}...")
+    fam_apps = crud_application.get_applications_by_granted_apps(
+        db=db, access_roles=access_roles_fam_only
+    )
+    LOGGER.debug(f"Apps: {fam_apps}")
+    assert len(fam_apps) == 1
+    assert str(fam_apps[0].application_name).lower() == "fam"
+
+    # Testing 'get_applications_by_granted_apps' with Accss Roles: FOM_DEV_ACCESS_ADMIN only
+    access_roles_fom_dev_only = ["FOM_DEV_ACCESS_ADMIN"]
+    LOGGER.debug(f"Testing 'get_applications_by_granted_apps' with Accss Roles: {access_roles_fom_dev_only}...")
+    fam_apps = crud_application.get_applications_by_granted_apps(
+        db=db, access_roles=access_roles_fom_dev_only
+    )
+    LOGGER.debug(f"Apps: {fam_apps}")
+    assert len(fam_apps) == 1
+    assert str(fam_apps[0].application_name).lower() == "fom_dev"
+
+    # Testing 'get_applications_by_granted_apps' with Accss Roles: both FAM_ACCESS_ADMIN and FOM_DEV_ACCESS_ADMIN
+    access_roles_fam__fom_dev = ["FAM_ACCESS_ADMIN", "FOM_DEV_ACCESS_ADMIN"]
+    LOGGER.debug(f"Testing 'get_applications_by_granted_apps' with Accss Roles: {access_roles_fam__fom_dev}...")
+    fam_apps = crud_application.get_applications_by_granted_apps(
+        db=db, access_roles=access_roles_fam__fom_dev
+    )
+    LOGGER.debug(f"Apps: {fam_apps}")
+    assert len(fam_apps) == 2
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fam"]) == 1
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fom_dev"]) == 1
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fom_test"]) == 0
+
+    # Testing 'get_applications_by_granted_apps' with Accss Roles: on FOM_DEV_ACCESS_ADMIN and FOM_TEST_ACCESS_ADMIN
+    access_roles_fom_dev_test = ["FOM_DEV_ACCESS_ADMIN", "FOM_TEST_ACCESS_ADMIN"]
+    LOGGER.debug(f"Testing 'get_applications_by_granted_apps' with Accss Roles: {access_roles_fom_dev_test}...")
+    fam_apps = crud_application.get_applications_by_granted_apps(
+        db=db, access_roles=access_roles_fom_dev_test
+    )
+    LOGGER.debug(f"Apps: {fam_apps}")
+    assert len(fam_apps) == 2
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fam"]) == 0
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fom_dev"]) == 1
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fom_test"]) == 1
+
+    # Testing 'get_applications_by_granted_apps' with Accss Roles: on NO_APP_ACCESS_ADMIN
+    access_roles_no_app = ["NO_APP_ACCESS_ADMIN"]
+    LOGGER.debug(f"Testing 'get_applications_by_granted_apps' with Accss Roles: {access_roles_no_app}...")
+    fam_apps = crud_application.get_applications_by_granted_apps(
+        db=db, access_roles=access_roles_no_app
+    )
+    # Shold have empty apps result.
+    LOGGER.debug(f"Apps: {fam_apps}")
+    assert len(fam_apps) == 0
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fam"]) == 0
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fom_dev"]) == 0
+    assert len([app for app in fam_apps if str(app.application_name).lower() == "fom_test"]) == 0

--- a/server/backend/tests/crud/test_crud_utils.py
+++ b/server/backend/tests/crud/test_crud_utils.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 import api.app.models.model as model
 from api.app.crud import crud_user
 from api.app.crud import crud_utils
@@ -38,3 +40,37 @@ def test_get_next(dbsession_fam_users, userdata2_pydantic, delete_all_users):
 
     next_value_after = crud_utils.get_next(db=db, model=fam_user_model)
     assert next_value_after > next_value_before
+
+
+@pytest.mark.parametrize("str_list_to_test, expcted_str_list",[
+    (['fam', 'fom', 'aws'], ['FAM', 'FOM', 'AWS']),
+    (['FAM', 'FOM', 'AWS'], ['FAM', 'FOM', 'AWS']),
+    (None, None)
+])
+def test_to_upper(str_list_to_test, expcted_str_list):
+    result = crud_utils.to_upper(str_list_to_test)
+    if result:
+        for index, r in enumerate(result):
+            assert r == expcted_str_list[index]
+    else:
+        assert result == expcted_str_list
+
+
+@pytest.mark.parametrize("str_list_to_test, str_to_replace, replace_with, expcted_str_list",[
+    (['FAM_ACCESS_ADMIN', 'FOM_DEV_ACCESS_ADMIN', 'FOM_TEST_ACCESS_ADMIN'], 
+     "_ACCESS_ADMIN", "",
+     ['FAM', 'FOM_DEV', 'FOM_TEST']
+    ),
+    (['FAM_ACCESS', 'FOM_DEV', 'FOM'], 
+     "_ACCESS", "_ACCESS_ADMIN",
+     ['FAM_ACCESS_ADMIN', 'FOM_DEV', 'FOM']
+    ),
+    (None, "something", "some_other_thing", None)
+])
+def test_replace_str_list(str_list_to_test, str_to_replace, replace_with, expcted_str_list):
+    result = crud_utils.replace_str_list(str_list_to_test, str_to_replace, replace_with)
+    if result:
+        for index, r in enumerate(result):
+            assert r == expcted_str_list[index]
+    else:
+        assert result == expcted_str_list

--- a/server/backend/tests/fixtures/fixtures_crud_application.py
+++ b/server/backend/tests/fixtures/fixtures_crud_application.py
@@ -302,28 +302,28 @@ def dbsession_different_envs_apps(
     db = dbsession_fam_app_environment
 
     fam_app = models.FamApplication(**{
-        "application_name": "fam",
+        "application_name": "FAM",
         "application_description": "Forests Access Management",
         "app_environment": None,
         "create_user": constants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     dev_fom_app = models.FamApplication(**{
-        "application_name": "fom_dev",
+        "application_name": "FOM_DEV",
         "application_description": "Forest Operations Map (DEV)",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_DEV,
         "create_user": constants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     test_fom_app = models.FamApplication(**{
-        "application_name": "fom_test",
+        "application_name": "FOM_TEST",
         "application_description": "Forest Operations Map (TEST)",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_TEST,
         "create_user": constants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     prod_fom_app = models.FamApplication(**{
-        "application_name": "fom_prod",
+        "application_name": "FOM_PROD",
         "application_description": "Forest Operations Map (PROD)",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_PROD,
         "create_user": constants.FAM_PROXY_API_USER,

--- a/server/backend/tests/fixtures/fixtures_crud_application.py
+++ b/server/backend/tests/fixtures/fixtures_crud_application.py
@@ -293,3 +293,52 @@ def dbsession_fam_app_environment(
     db.delete(test_app_environment)
     db.delete(prod_app_environment)
     db.flush()
+
+
+@pytest.fixture(scope="function")
+def dbsession_different_envs_apps(
+    dbsession_fam_app_environment: sqlalchemy.orm.session.Session
+) -> sqlalchemy.orm.session.Session:
+    db = dbsession_fam_app_environment
+
+    fam_app = models.FamApplication(**{
+        "application_name": "fam",
+        "application_description": "Forests Access Management",
+        "app_environment": None,
+        "create_user": constants.FAM_PROXY_API_USER,
+        "create_date": datetime.datetime.now(),
+    })
+    dev_fom_app = models.FamApplication(**{
+        "application_name": "fom_dev",
+        "application_description": "Forest Operations Map (DEV)",
+        "app_environment": constants.AppEnv.APP_ENV_TYPE_DEV,
+        "create_user": constants.FAM_PROXY_API_USER,
+        "create_date": datetime.datetime.now(),
+    })
+    test_fom_app = models.FamApplication(**{
+        "application_name": "fom_test",
+        "application_description": "Forest Operations Map (TEST)",
+        "app_environment": constants.AppEnv.APP_ENV_TYPE_TEST,
+        "create_user": constants.FAM_PROXY_API_USER,
+        "create_date": datetime.datetime.now(),
+    })
+    prod_fom_app = models.FamApplication(**{
+        "application_name": "fom_prod",
+        "application_description": "Forest Operations Map (PROD)",
+        "app_environment": constants.AppEnv.APP_ENV_TYPE_PROD,
+        "create_user": constants.FAM_PROXY_API_USER,
+        "create_date": datetime.datetime.now(),
+    })
+    db.add(fam_app)
+    db.add(dev_fom_app)
+    db.add(test_fom_app)
+    db.add(prod_fom_app)
+
+    db.flush()
+    yield db
+
+    db.delete(fam_app)
+    db.delete(dev_fom_app)
+    db.delete(test_fom_app)
+    db.delete(prod_fom_app)
+    db.flush()

--- a/server/flyway/sql/V21__upper_case_application_name.sql
+++ b/server/flyway/sql/V21__upper_case_application_name.sql
@@ -1,0 +1,26 @@
+-- Running upgrade V20 -> V21
+-- Update fam_application.application_name to upper case.
+
+UPDATE app_fam.fam_application
+SET (application_name, update_user, update_date) =
+	('FAM', CURRENT_USER, CURRENT_DATE)
+WHERE application_name = 'fam'
+;
+
+UPDATE app_fam.fam_application
+SET (application_name, update_user, update_date) =
+	('FOM_DEV', CURRENT_USER, CURRENT_DATE)
+WHERE application_name = 'fom_dev'
+;
+
+UPDATE app_fam.fam_application
+SET (application_name, update_user, update_date) =
+	('FOM_TEST', CURRENT_USER, CURRENT_DATE)
+WHERE application_name = 'fom_test'
+;
+
+UPDATE app_fam.fam_application
+SET (application_name, update_user, update_date) =
+	('FOM_PROD', CURRENT_USER, CURRENT_DATE)
+WHERE application_name = 'fom_prod'
+;


### PR DESCRIPTION
This is part of #359:

- Add 'jwt_validation.get_access_roles' for use as a convenient router dependency to get access roles.
- Get Applications endpoint uses new "get_applications_by_granted_apps" function to filter on app's name
  based on Token's access roles.
- Add few tests for the new get_applications_by_granted_apps function.