### PR TITLE
#399 Fix loading errors

### DIFF
--- a/frontend/src/components/SelectApplication.vue
+++ b/frontend/src/components/SelectApplication.vue
@@ -2,7 +2,6 @@
 import PageTitle from '@/components/PageTitle.vue';
 import { ApiServiceFactory } from '@/services/ApiServiceFactory';
 import { applicationsUserAdministers, isApplicationSelected, selectedApplication } from '@/services/ApplicationState';
-import type { FamApplication, FAMApplicationsApi } from 'fam-api';
 import { useToast } from 'vue-toastification';
 import router from '../router';
 
@@ -15,16 +14,8 @@ setTimeout( async () => {
   try {
     applicationsUserAdministers.value = (await applicationsApi.getApplications()).data
   } catch (error) {
-    const toast = useToast();
+    const toast = useToast()
     toast.error("An error occurred loading applications. Please refresh the screen.\n If the error persists, try again later or contact support.")
-    // TODO: Workaround broken front-end. Remove once front-end is stable.
-    toast.warning("Using fake test data as temporary working for applications not working. REMOVE BEFORE PRODUCTION.")
-    applicationsUserAdministers.value = [
-      { application_name: 'FOM', application_description: 'Forest Operations Map', application_id: 1001 },
-      { application_name: 'FAM', application_description: 'Forest Access Management', application_id: 1002 },
-      { application_name: 'FAKE', application_description: 'Fake Test App', application_id: 9999 }
-    ] as FamApplication[]
-
   }
 
   // If user can only manage one application redirect to manage access screen

--- a/frontend/src/components/SelectApplication.vue
+++ b/frontend/src/components/SelectApplication.vue
@@ -7,7 +7,6 @@ import router from '../router';
 
 const apiServiceFactory = new ApiServiceFactory()
 const applicationsApi = apiServiceFactory.getApplicationApi()
-
 onMounted(async () => {
   // Reload list each time we navigate to this page to avoid forcing user to refresh if their access changes.
   try {
@@ -68,14 +67,14 @@ onMounted(async () => {
             <button type="button"
               id="goToManageAccessButton"
               class="btn btn-info mb-3"
-              :disabled="isApplicationSelected"
+              :disabled="!isApplicationSelected"
               @click="router.push('/manage')">Manage Access</button>
           </div>
           <div class="col-auto">
             <button type="button"
               id="goToGrantAccessButton"
               class="btn btn-primary mb-3"
-              :disabled="isApplicationSelected"
+              :disabled="!isApplicationSelected"
               @click="router.push('/grant')">Grant Access</button>
           </div>
         </div>

--- a/frontend/src/components/SelectApplication.vue
+++ b/frontend/src/components/SelectApplication.vue
@@ -10,12 +10,13 @@ const applicationsApi = apiServiceFactory.getApplicationApi()
 
 // Using timeout to implement lazy loading. Component will render and display loading message until this finishes.
 setTimeout( async () => {
-  // Reload list each time we navigate to this page to avoid forcing user to refresh if their access changes.
+  // Reload list each time we navigate to this page. This could be cached, as user's token determines roles granting access to applications.
   try {
     applicationsUserAdministers.value = (await applicationsApi.getApplications()).data
   } catch (error) {
     const toast = useToast()
     toast.error("An error occurred loading applications. Please refresh the screen.\n If the error persists, try again later or contact support.")
+    console.log(`Error loading applications due to ${error}`)
   }
 
   // If user can only manage one application redirect to manage access screen

--- a/frontend/src/services/ApplicationState.ts
+++ b/frontend/src/services/ApplicationState.ts
@@ -8,7 +8,7 @@ export const applicationsUserAdministers = ref<FamApplication[]>([])
 export const selectedApplication = ref<FamApplication>()
 
 export const isApplicationSelected = computed( () => {
-    return selectedApplication.value == null
+    return selectedApplication.value != undefined
   })
 
 export const selectedApplicationShortDisplayText = computed( () => {

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -36,7 +36,7 @@ async function login() {
 
 async function logout() {
     Auth.signOut()
-    storeFamUser(undefined)
+    removeFamUser()
     console.log("User logged out.")
     router.push('/')
 }
@@ -97,6 +97,10 @@ function parseToken(authToken: CognitoUserSession): FamLoginUser {
     return famLoginUser;
 }
 
+function removeFamUser() {
+    storeFamUser(undefined)
+}
+
 function storeFamUser(famLoginUser: FamLoginUser | null | undefined) {
     state.value.famLoginUser = famLoginUser
     if (famLoginUser) {
@@ -113,7 +117,8 @@ const methods = {
     login,
     handlePostLogin,
     logout,
-    refreshToken
+    refreshToken,
+    removeFamUser
 }
 
 const getters = {

--- a/frontend/src/services/ErrorService.ts
+++ b/frontend/src/services/ErrorService.ts
@@ -1,24 +1,37 @@
 import { useToast } from "vue-toastification"
-import type { AxiosError } from 'axios'
+import axios, { type AxiosError } from "axios";
 
-function onError(error: unknown, info: string) {
+function onError(error: any, info: string) {
+    console.error(`Error occurred: ${error.toString()}`)
     const toast = useToast();
-    const err = error as AxiosError
+    const genericErrorMsg = "An application error has occurred. Please try again. If the error persists contact support."
 
-    console.error(`app.config.errorHandler error ${err} with info: ${info}`)
-    if (err.response?.status == 401) {
-      toast.error('You are not logged in. Please log in.')
-      return
+    // Axios Http instance error that we like to pop out additional toast message.
+    if (axios.isAxiosError(error)) {
+        const err = error as AxiosError
+        const axiosResponse = err.response
+        const status = axiosResponse?.status
+
+        const e401_authenticationErrorMsg = "You are not logged in. Please log in."
+        const e403_authorizationErrorMsg = "You do not have the necessary authorization for the requested action."
+        const e409_conflictErrorMsg = `${axiosResponse?.data.detail}`
+
+        if (!status) {
+            toast.error(genericErrorMsg)
+        }
+        else if (status == 401) {
+            toast.error(e401_authenticationErrorMsg)
+        }
+        else if (status == 403) {
+            toast.error(e403_authorizationErrorMsg)
+        }
+        else if (status == 409) {
+            toast.warning(e409_conflictErrorMsg)
+        }
+        return
     }
-    if (err.response?.status == 403) {
-      toast.error('You do not have the necessary authorization for the requested action.')
-      return
-    }
-    if (err.response?.status == 409) {
-      toast.warning(`${err.response?.data.detail}`)
-      return
-    }
-    toast.error('An application error has occurred. Please try again. If the error persists contact support.')
+
+    toast.error(genericErrorMsg)
 }
 
 export default {

--- a/frontend/src/services/http/HttpCommon.ts
+++ b/frontend/src/services/http/HttpCommon.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 const environmentSettings = new EnvironmentSettings()
 const apiBaseUrl = environmentSettings.getApiBaseUrl()
 const DEFAULT_CONTENT_TYPE = 'application/json';
-const DEFAULT_REQUEST_TIMEOUT = 5000;
+const DEFAULT_REQUEST_TIMEOUT = 20000;
 
 const defaultAxiosConfig = {
     baseURL: apiBaseUrl,

--- a/frontend/src/services/http/HttpCommon.ts
+++ b/frontend/src/services/http/HttpCommon.ts
@@ -32,7 +32,8 @@ httpInstance.defaults.headers.get['Content-type'] = DEFAULT_CONTENT_TYPE;
 httpInstance.interceptors.request.use(HttpReqInterceptors.addAuthHeaderItcpt);
 
 // Response Interceptors
-httpInstance.interceptors.response.use(response => response, HttpResInterceptors.accessErrorResponsesItcpt); // Provide error block handling.
+httpInstance.interceptors.response.use(response => response, HttpResInterceptors.authenticationErrorResponsesItcpt); // 401 error handler
+httpInstance.interceptors.response.use(response => response, HttpResInterceptors.forbiddenErrorResponseItcpt); // 403 error handler
 
 
 

--- a/frontend/src/services/http/HttpResponseInterceptors.ts
+++ b/frontend/src/services/http/HttpResponseInterceptors.ts
@@ -14,27 +14,35 @@ const MAX_RETRY = 2
 // --- Interceptors
 
 // Assume it is caught in error block based on default handling.
-async function accessErrorResponsesItcpt(error: any) {
-    // 401 special handling; until MAX_RETRY reached.
-    if (error.response.status == 401 && (retryCount.value < MAX_RETRY)) {
-        return refreshTokenAndReTry(error.config, error.response);
-    }
-    if (error.response.status == 403) {
-        router.push('/')
-        return Promise.reject(error);
+// 401 Interceptor
+async function authenticationErrorResponsesItcpt(error: any) {
+    // Special handling; until MAX_RETRY reached.
+    if (error.response?.status == 401) {
+        if ((retryCount.value < MAX_RETRY)) {
+            return refreshTokenAndReTry(error.config, error.response);
+        }
+        AuthService.methods.removeFamUser() // Done retry refresh token, token expired; remove user.
     }
 
     retryCount.value = 0 // reset counter when retry ends or not 401.
+    return Promise.reject(error); // return error for next interceptor.
+}
+
+// 403 Interceptor
+async function forbiddenErrorResponseItcpt(error: any) {
+    if (error.response?.status == 403) {
+        router.replace('/') // Unauthorized operation, direct back to home.
+    }
     return Promise.reject(error);
 }
 
-async function refreshTokenAndReTry(request: AxiosRequestConfig, response: AxiosResponse) {
+async function refreshTokenAndReTry(config: AxiosRequestConfig, response: AxiosResponse) {
     // Refresh token.
     await AuthService.methods.refreshToken()
 
     // Try original request again.
     retryCount.value++
-    return Http.request(request)
+    return Http.request(config)
         .catch((error) => {
             console.log("Still encountered error after request retried: ", error)
             return Promise.reject(error);
@@ -42,5 +50,6 @@ async function refreshTokenAndReTry(request: AxiosRequestConfig, response: Axios
 }
 
 export default {
-    accessErrorResponsesItcpt
+    authenticationErrorResponsesItcpt,
+    forbiddenErrorResponseItcpt
 }

--- a/server/backend/api/app/crud/crud_utils.py
+++ b/server/backend/api/app/crud/crud_utils.py
@@ -88,5 +88,5 @@ def get_application_id_from_name(db, application_name):
 
 
 def raise_http_exception(status_code: str, error_msg: str):
-    LOGGER.error(error_msg)
+    LOGGER.info(error_msg)
     raise HTTPException(status_code=status_code, detail=error_msg)

--- a/server/backend/api/app/jwt_validation.py
+++ b/server/backend/api/app/jwt_validation.py
@@ -52,11 +52,11 @@ _jwks = None
 
 def init_jwks():
     global _jwks
-    on_aws = os.environ.get("DB_SECRET")  # This key only presents on aws.
     # why not use the global versions of these variables, lines 34, 35
     aws_region = get_aws_region()
     user_pool_id = get_user_pool_id()
     # Add try/except due to urlopen() may have problem reaching AWS/Cognito.
+    LOGGER.debug(f"Requesting aws jwks with region {aws_region} and user pood id {user_pool_id}...")
     try:
         with urlopen(f"https://cognito-idp.{aws_region}.amazonaws.com/{user_pool_id}/.well-known/jwks.json") as response:
             _jwks = json.loads(response.read().decode('utf-8'))
@@ -64,9 +64,7 @@ def init_jwks():
     except Exception as e:
         LOGGER.error(f"init_jwks function failed to reach AWS: {e}.")
         LOGGER.error("Backend API will not work properly.")
-        # Raise original exception but tolerate this error for local development.
-        if on_aws:
-            raise e
+        raise e
 
 
 def get_rsa_key_method():


### PR DESCRIPTION
- Fix logic error (conflict with naming) for "isApplicationSelected" state usage.
- Adjust ErrorService so it can log Axios errors (using "isAxiosError") and also log common javascript errors.
- Separate 401 and 403 responses into two interceptors.
- Use "info" level for logging at backend to prevent confusion for real error.