### PR TITLE
386-init-app-blank-page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="favicon.ico" />
-    <link rel="preload" href="/env.json" as="fetch" crossorigin="anonymous" type="application/json">
+    <!-- 
+      Important to preload static environment settings 'env.json' first at run time.
+      It is to prepare for later App needs, especially for Amplify's configuring for Cognito communication for login.
+      Some reference here: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload
+    -->
+    <link rel="preload" href="/env.json" as="fetch" crossorigin="anonymous" type="application/json" />
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FAM - Forest Access Management</title>
     <script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,12 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="favicon.ico" />
+    <link rel="preload" href="/env.json" as="fetch" crossorigin="anonymous" type="application/json">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FAM - Forest Access Management</title>
     <script>
       // Fix `global is not defined` error caused by 'amazon-cognito-identity-js/es/AuthenticationHelper.js'.
       // The best solution might be in vite.config.ts, but for some reason, the fix in vite.config.ts (works) conflicts with
-      // configured "Vitest" internally. If we use --dom option for npm test (happy-dom), the fix in config will have no problem; 
+      // configured "Vitest" internally. If we use --dom option for npm test (happy-dom), the fix in config will have no problem;
       // but we are using jsdom currently. So, instead, define 'global' here at index.html.
       // vite.config.ts (add this, but does not work for 'jsdom'):
       //  define: {
@@ -18,7 +19,7 @@
 
     </script>
     <script src="/env.js">
-    </script> 
+    </script>
   </head>
   <body id="fam-body" class="fam-body">
     <div id="main-body">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
-
-import awsExports from '@/aws-exports';
 import Breadcrumb from '@/components/Breadcrumb.vue';
 import Footer from '@/components/footer/Footer.vue';
 import Header from '@/components/header/Header.vue';
-import { Amplify } from 'aws-amplify';
 import { RouterView } from 'vue-router';
 
-Amplify.configure(awsExports); // Config Amplify for Cognito resource.
-  
 </script>
 
 <template>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 
-  import { RouterView } from 'vue-router'
-  import Header from '@/components/header/Header.vue'
-  import Footer from '@/components/footer/Footer.vue'
-  import Breadcrumb from '@/components/Breadcrumb.vue'
+import awsExports from '@/aws-exports';
+import Breadcrumb from '@/components/Breadcrumb.vue';
+import Footer from '@/components/footer/Footer.vue';
+import Header from '@/components/header/Header.vue';
+import { Amplify } from 'aws-amplify';
+import { RouterView } from 'vue-router';
 
+Amplify.configure(awsExports); // Config Amplify for Cognito resource.
+  
 </script>
 
 <template>

--- a/frontend/src/aws-exports.js
+++ b/frontend/src/aws-exports.js
@@ -1,3 +1,12 @@
+/**
+ * This aws-exports is the configuration for Amplify library to communicate with AWS Cognito.
+ * It uses generated (different in each environment) "env.json" static file that is
+ * being loaded and stored in user's browser storage at run time. (See env.js at index.html)
+ *
+ * A note for purpose of using optional ("env?.") is that this is not to skip values when "env"
+ * is not loaded. When there is no "env.json" loaded yet, the error message is strange; so give it
+ * optional "?" simply let the down stram Amplify to throw more meaningful error.
+ */
 const env = JSON.parse(window.localStorage.getItem('env_data'))
 
 const config = {
@@ -14,5 +23,5 @@ const config = {
     },
     federationTarget: 'COGNITO_USER_POOLS',
   };
-  
+
   export default config;

--- a/frontend/src/aws-exports.js
+++ b/frontend/src/aws-exports.js
@@ -1,15 +1,15 @@
 const env = JSON.parse(window.localStorage.getItem('env_data'))
 
 const config = {
-    aws_cognito_region: env.fam_cognito_region.value,
-    aws_user_pools_id: env.fam_user_pool_id.value,
-    aws_user_pools_web_client_id: env.fam_console_web_client_id.value, // This is App Client Id
+    aws_cognito_region: env?.fam_cognito_region.value,
+    aws_user_pools_id: env?.fam_user_pool_id.value,
+    aws_user_pools_web_client_id: env?.fam_console_web_client_id.value, // This is App Client Id
     aws_mandatory_sign_in: 'enable',
     oauth: {
-      domain: `${env.fam_cognito_domain.value}.auth.ca-central-1.amazoncognito.com`,
+      domain: `${env?.fam_cognito_domain.value}.auth.ca-central-1.amazoncognito.com`,
       scope: ['openid'],
-      redirectSignIn: `${env.front_end_redirect_base_url.value}/authCallback`, // For some reason, vue nested path (/cognito/callback) does not work yet.
-      redirectSignOut: `${env.front_end_redirect_base_url.value}/authLogout`,
+      redirectSignIn: `${env?.front_end_redirect_base_url.value}/authCallback`, // For some reason, vue nested path (/cognito/callback) does not work yet.
+      redirectSignOut: `${env?.front_end_redirect_base_url.value}/authLogout`,
       responseType: 'code',
     },
     federationTarget: 'COGNITO_USER_POOLS',

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,7 +9,8 @@ import router from '@/router'
 
 import 'bootstrap'
 import './assets/styles/styles.scss'
-
+import { Amplify } from 'aws-amplify'
+import awsExports from './aws-exports'
 
 // import the fontawesome core
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -22,6 +23,8 @@ import { faTrashCan } from '@fortawesome/free-regular-svg-icons'
 
 // add specific icons to library for use throughout application
 library.add(faTrashCan)
+
+Amplify.configure(awsExports); // Config Amplify for Cognito resource.
 
 const app = createApp(App)
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,17 +1,14 @@
 import { createApp } from 'vue'
 
-import Toast, { useToast, type PluginOptions, POSITION, TYPE } from "vue-toastification"
-import "vue-toastification/dist/index.css"
-
-import { Amplify } from 'aws-amplify'
-import awsExports from './aws-exports'
 import { vfmPlugin } from 'vue-final-modal'
+import Toast, { POSITION, TYPE, useToast, type PluginOptions } from "vue-toastification"
+import "vue-toastification/dist/index.css"
 
 import App from '@/App.vue'
 import router from '@/router'
 
-import './assets/styles/styles.scss'
 import 'bootstrap'
+import './assets/styles/styles.scss'
 
 
 // import the fontawesome core
@@ -25,8 +22,6 @@ import { faTrashCan } from '@fortawesome/free-regular-svg-icons'
 
 // add specific icons to library for use throughout application
 library.add(faTrashCan)
-
-Amplify.configure(awsExports); // Config Amplify for Cognito resource.
 
 const app = createApp(App)
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,9 +7,9 @@ import "vue-toastification/dist/index.css"
 import App from '@/App.vue'
 import router from '@/router'
 
+import { Amplify } from 'aws-amplify'
 import 'bootstrap'
 import './assets/styles/styles.scss'
-import { Amplify } from 'aws-amplify'
 import awsExports from './aws-exports'
 
 // import the fontawesome core

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -3,9 +3,13 @@ import type { CognitoUserSession } from 'amazon-cognito-identity-js';
 import { Auth } from 'aws-amplify';
 import { readonly, ref } from 'vue';
 import awsExports from '@/aws-exports';
+import { configDefaults } from 'vitest/config'
 
 const FAM_LOGIN_USER = 'famLoginUser'
-setTimeout(() => Auth.configure(awsExports), 1000); // Config Amplify for Cognito resource.
+if (!process.env.VITEST) { // if Test mode, skip Auth configuring.
+    setTimeout(() => Auth.configure(awsExports), 1000); // Config Amplify for Cognito resource.
+}
+
 
 export interface FamLoginUser {
     username?: string,

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -2,13 +2,10 @@ import router from '@/router';
 import type { CognitoUserSession } from 'amazon-cognito-identity-js';
 import { Auth } from 'aws-amplify';
 import { readonly, ref } from 'vue';
-import awsExports from '@/aws-exports';
-import { configDefaults } from 'vitest/config'
+// import awsExports from '@/aws-exports';
 
 const FAM_LOGIN_USER = 'famLoginUser'
-if (!process.env.VITEST) { // if Test mode, skip Auth configuring.
-    setTimeout(() => Auth.configure(awsExports), 1000); // Config Amplify for Cognito resource.
-}
+// setTimeout(() => Auth.configure(awsExports), 1000); // Config Amplify for Cognito resource.
 
 
 export interface FamLoginUser {

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -2,8 +2,10 @@ import router from '@/router';
 import type { CognitoUserSession } from 'amazon-cognito-identity-js';
 import { Auth } from 'aws-amplify';
 import { readonly, ref } from 'vue';
+import awsExports from '@/aws-exports';
 
 const FAM_LOGIN_USER = 'famLoginUser'
+Auth.configure(awsExports); // Config Amplify for Cognito resource.
 
 export interface FamLoginUser {
     username?: string,
@@ -13,7 +15,7 @@ export interface FamLoginUser {
 }
 
 const state = ref({
-    famLoginUser: localStorage.getItem(FAM_LOGIN_USER)? 
+    famLoginUser: localStorage.getItem(FAM_LOGIN_USER)?
                     JSON.parse(localStorage.getItem(FAM_LOGIN_USER) as string) as (FamLoginUser | undefined | null)
                     : undefined,
 })
@@ -27,7 +29,7 @@ function isLoggedIn(): boolean {
 
 async function login() {
     /*
-        See Aws-Amplify documenation: 
+        See Aws-Amplify documenation:
         https://docs.amplify.aws/lib/auth/social/q/platform/js/
         https://docs.amplify.aws/lib/auth/advanced/q/platform/js/#identity-pool-federation
     */
@@ -54,12 +56,12 @@ async function handlePostLogin() {
 }
 
 /**
- * Amplify method currentSession() will automatically refresh the accessToken and idToken 
+ * Amplify method currentSession() will automatically refresh the accessToken and idToken
  * if tokens are "expired" and a valid refreshToken presented.
  *   // console.log("currentAuthToken: ", currentAuthToken)
  *   // console.log("ID Token: ", currentAuthToken.getIdToken().getJwtToken())
  *   // console.log("Access Token: ", currentAuthToken.getAccessToken().getJwtToken())
- * 
+ *
  * Automatically logout if unable to get currentSession().
  */
 async function refreshToken(): Promise<FamLoginUser | undefined> {
@@ -80,7 +82,7 @@ async function refreshToken(): Promise<FamLoginUser | undefined> {
 }
 
 /**
- * See OIDC Attribute Mapping mapping reference: 
+ * See OIDC Attribute Mapping mapping reference:
  *      https://github.com/bcgov/nr-forests-access-management/wiki/OIDC-Attribute-Mapping
  * Note, current user data return for 'userData.username' is matched to "cognito:username" on Cognito.
  * Which isn't what we really want to display. The display username is "custom:idp_username" from token.
@@ -123,5 +125,5 @@ const getters = {
 export default {
     state: readonly(state), // readonly to prevent direct state change; force it through methods if needed to.
     methods,
-    getters 
+    getters
 }

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -5,7 +5,7 @@ import { readonly, ref } from 'vue';
 import awsExports from '@/aws-exports';
 
 const FAM_LOGIN_USER = 'famLoginUser'
-Auth.configure(awsExports); // Config Amplify for Cognito resource.
+setTimeout(() => Auth.configure(awsExports), 1000); // Config Amplify for Cognito resource.
 
 export interface FamLoginUser {
     username?: string,

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -2,11 +2,8 @@ import router from '@/router';
 import type { CognitoUserSession } from 'amazon-cognito-identity-js';
 import { Auth } from 'aws-amplify';
 import { readonly, ref } from 'vue';
-// import awsExports from '@/aws-exports';
 
 const FAM_LOGIN_USER = 'famLoginUser'
-// setTimeout(() => Auth.configure(awsExports), 1000); // Config Amplify for Cognito resource.
-
 
 export interface FamLoginUser {
     username?: string,


### PR DESCRIPTION
This is for ticket #386.
From observations, this initial blank page only happens during user's "**first time**" (particularly when no browser caching from previous loading) accessing the FAM site.
Found that web browser stack can use "**preload**" for preloading some content for **performance** and that seems to solve the problem. Tested few times on browsers (Chrome/Edge) with clear caching and inPrivate mode, I observed it is consistent now with no blank page issue.