### PR TITLE
Fix/367 id token header not allowed

### DIFF
--- a/frontend/src/services/http/HttpRequestInterceptors.ts
+++ b/frontend/src/services/http/HttpRequestInterceptors.ts
@@ -8,10 +8,13 @@ import type { AxiosRequestConfig } from 'axios';
 function addAuthHeaderItcpt(config: AxiosRequestConfig) {
     const authToken = authService.state.value.famLoginUser?.authToken
     if (authToken) {
-        const authHeader = `Bearer ${authToken.getAccessToken().getJwtToken()}`
-        const idTokenHeader = authToken.getIdToken().getJwtToken()
-        config.headers? (config.headers['Authorization'] = authHeader, config.headers['id-token'] = idTokenHeader)
-                      : (config.headers = {'Authorization': authHeader}, config.headers = {'id-token': idTokenHeader})
+        const bearerToken = JSON.stringify({
+            "id_token": authToken.getIdToken().getJwtToken(),
+            "access_token": authToken.getAccessToken().getJwtToken()})
+        const authHeader = `Bearer ${bearerToken}`
+
+        config.headers? (config.headers['Authorization'] = authHeader)
+                      : (config.headers = {'Authorization': authHeader})
     }
     return config
 }

--- a/server/backend/api/app/jwt_validation.py
+++ b/server/backend/api/app/jwt_validation.py
@@ -97,9 +97,10 @@ def validate_token(
     token: str = Depends(oauth2_scheme),
     get_rsa_key_method: callable = Depends(get_rsa_key_method)
 ) -> dict:
-
+    json_token = json.loads(token)
+    access_token = json_token.get("access_token")
     try:
-        unverified_header = jwt.get_unverified_header(token)
+        unverified_header = jwt.get_unverified_header(access_token)
     except jwt.JWTError:
         raise HTTPException(
             status_code=401,
@@ -146,12 +147,11 @@ def validate_token(
 
     try:
         jwt.decode(
-            token,
+            access_token,
             rsa_key,
             algorithms='RS256',
             issuer=f"https://cognito-idp.{aws_region}.amazonaws.com/{user_pool_id}"
         )
-
     except jwt.ExpiredSignatureError:
         LOGGER.debug("Caught exception jwt expired")
         raise HTTPException(
@@ -175,7 +175,7 @@ def validate_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    claims = jwt.get_unverified_claims(token)
+    claims = jwt.get_unverified_claims(access_token)
 
     if claims[JWT_CLIENT_ID_KEY] != get_oidc_client_id():
         raise HTTPException(

--- a/server/backend/api/app/routers/router_user_role_assignment.py
+++ b/server/backend/api/app/routers/router_user_role_assignment.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+import json
 import logging
 
 from api.app.crud import crud_user_role, crud_application
@@ -29,7 +30,8 @@ def create_user_role_assignment(
         db, role_assignment_request.role_id)
     jwt_validation.authorize_by_app_id(application_id, db, token_claims)
 
-    id_token = request.headers.get('id-token')
+    token = str(request.headers.get("Authorization"))
+    id_token = json.loads(token[len("Bearer "):]).get("id_token")
     username = jwt_validation.get_username_from_id_token(id_token)
 
     create_data = crud_user_role.create_user_role(

--- a/server/backend/tests/authorization/test_authorization.py
+++ b/server/backend/tests/authorization/test_authorization.py
@@ -6,10 +6,10 @@ from mock_alchemy.mocking import UnifiedAlchemyMagicMock
 from api.app.main import apiPrefix
 from api.app import database
 from api.app.models import model as models
-from tests.jwt_utils import (create_jwt_token,
-                        create_jwt_claims,
-                        assert_error_response,
-                        headers)
+from tests.jwt_utils import (create_jwt_access_token,
+                             create_jwt_access_claims,
+                             assert_error_response,
+                             headers)
 
 from api.app.jwt_validation import (ERROR_GROUPS_REQUIRED,
                                     ERROR_PERMISSION_REQUIRED,
@@ -21,27 +21,29 @@ fam_applications_endpoint = f"{apiPrefix}/fam_applications"
 
 def test_get_application_missing_groups_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    claims = create_jwt_claims()
+    claims = create_jwt_access_claims()
     claims.pop(JWT_GROUPS_KEY)
-    token = create_jwt_token(test_rsa_key, claims)
+    access_token = create_jwt_access_token(test_rsa_key, claims)
 
     response = test_client_fixture_unit.get(f"{fam_applications_endpoint}",
-                                       headers=headers(token))
+                                            headers=headers(test_id_token, access_token))
 
     assert_error_response(response, 403, ERROR_GROUPS_REQUIRED)
 
 
 def test_get_application_no_groups_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    claims = create_jwt_claims()
+    claims = create_jwt_access_claims()
     claims[JWT_GROUPS_KEY] = []
-    token = create_jwt_token(test_rsa_key, claims)
+    access_token = create_jwt_access_token(test_rsa_key, claims)
 
     response = test_client_fixture_unit.get(f"{fam_applications_endpoint}",
-                                       headers=headers(token))
+                                            headers=headers(test_id_token, access_token))
 
     assert_error_response(response, 403, ERROR_GROUPS_REQUIRED)

--- a/server/backend/tests/authorization/test_jwt_validation.py
+++ b/server/backend/tests/authorization/test_jwt_validation.py
@@ -15,8 +15,8 @@ from api.app.jwt_validation import (ERROR_TOKEN_DECODE,
                                     ERROR_VALIDATION,
                                     JWT_CLIENT_ID_KEY)
 import json
-from jwt_utils import (create_jwt_token,
-                       create_jwt_claims,
+from jwt_utils import (create_jwt_access_token,
+                       create_jwt_access_claims,
                        assert_error_response,
                        headers)
 from Crypto.PublicKey import RSA
@@ -28,7 +28,8 @@ endPoint = f"{apiPrefix}/fam_applications"
 
 def test_get_application_success(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
     test_client_fixture_unit.app.dependency_overrides[database.get_db] = \
         lambda: UnifiedAlchemyMagicMock(data=[
@@ -37,9 +38,12 @@ def test_get_application_success(
             ),
         ])
 
-    token = create_jwt_token(test_rsa_key)
+    access_token = create_jwt_access_token(test_rsa_key)
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert response.status_code == 204
     data = response.json()
@@ -58,81 +62,109 @@ def test_get_application_no_authentication_failure(
 def test_get_application_bad_token_failure(
         test_client_fixture_unit: starlette.testclient.TestClient):
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers("12345"))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers("123", "456")
+    )
 
     assert_error_response(response, 401, ERROR_TOKEN_DECODE)
 
 
 def test_get_application_bad_client_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    claims = create_jwt_claims()
+    claims = create_jwt_access_claims()
     claims[JWT_CLIENT_ID_KEY] = "incorrect"
-    token = create_jwt_token(test_rsa_key, claims)
+    access_token = create_jwt_access_token(test_rsa_key, claims)
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_INVALID_CLIENT)
 
 
 def test_get_application_wrong_alg_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    claims = create_jwt_claims()
+    claims = create_jwt_access_claims()
     invalid_algorithm = 'HS256'
-    token = create_jwt_token(test_rsa_key, claims, invalid_algorithm)
+    access_token = create_jwt_access_token(test_rsa_key, claims, invalid_algorithm)
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_INVALID_ALGORITHM)
 
 
 def test_get_application_missing_kid_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    token = create_jwt_token(test_rsa_key, test_headers={})
+    access_token = create_jwt_access_token(test_rsa_key, test_headers={})
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_MISSING_KID)
 
 
 def test_get_application_missing_rsa_key_failure(
+        test_id_token,
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key_missing):
+        test_rsa_key_missing
+):
 
-    token = create_jwt_token(test_rsa_key_missing)
+    access_token = create_jwt_access_token(test_rsa_key_missing)
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_NO_RSA_KEY)
 
 
 def test_get_application_expired_token_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    claims = create_jwt_claims()
+    claims = create_jwt_access_claims()
     claims['exp'] = time.time() - 60000
-    token = create_jwt_token(test_rsa_key, claims)
+    access_token = create_jwt_access_token(test_rsa_key, claims)
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_EXPIRED_TOKEN)
 
 
 def test_get_application_bad_issuer_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
-    claims = create_jwt_claims()
+    claims = create_jwt_access_claims()
     claims['iss'] = 'incorrect'
-    token = create_jwt_token(test_rsa_key, claims)
+    access_token = create_jwt_access_token(test_rsa_key, claims)
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_CLAIMS)
     assert json.loads(response.text)['detail']['description'] == 'Invalid issuer'
@@ -140,13 +172,17 @@ def test_get_application_bad_issuer_failure(
 
 def test_get_application_invalid_signature_failure(
         test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+        test_rsa_key,
+        test_id_token):
 
     wrong_key = RSA.generate(2048)
 
-    token = create_jwt_token(wrong_key.exportKey("PEM"))
+    access_token = create_jwt_access_token(wrong_key.exportKey("PEM"))
 
-    response = test_client_fixture_unit.get(f"{endPoint}", headers=headers(token))
+    response = test_client_fixture_unit.get(
+        f"{endPoint}",
+        headers=headers(test_id_token, access_token)
+    )
 
     assert_error_response(response, 401, ERROR_VALIDATION)
 

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -13,6 +13,8 @@ https://fastapi.tiangolo.com/advanced/testing-database/
 import os
 import sys
 
+from jwt_utils import create_jwt_id_token
+
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import logging
@@ -20,20 +22,18 @@ import sys
 from typing import Any, Generator
 
 import api.app.database as database
+import api.app.jwt_validation as jwt_validation
 import api.app.models.model as model
 import pytest
 from api.app.database import Base
 from api.app.main import app
+from Crypto.PublicKey import RSA
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from mock_alchemy.mocking import UnifiedAlchemyMagicMock
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import sessionmaker
-from mock_alchemy.mocking import UnifiedAlchemyMagicMock
-
-from Crypto.PublicKey import RSA
-import api.app.jwt_validation as jwt_validation
-
 
 # global placeholder to be populated by fixtures for database test
 # sessions, required to override the get_db method.
@@ -237,3 +237,8 @@ def override_get_rsa_key_method_none():
 
 def override_get_rsa_key_none(kid):
     return None
+
+
+@pytest.fixture(scope="function")
+def test_id_token(test_rsa_key):
+    return create_jwt_id_token(test_rsa_key)

--- a/server/backend/tests/jwt_utils.py
+++ b/server/backend/tests/jwt_utils.py
@@ -1,8 +1,9 @@
-import os
-from jose import jws
-import time
 import json
+import os
+import time
 
+import pytest
+from jose import jws
 
 COGNITO_REGION = os.environ.get('COGNITO_REGION')
 COGNITO_USER_POOL_ID = os.environ.get('COGNITO_USER_POOL_ID')
@@ -10,7 +11,7 @@ COGNITO_CLIENT_ID = os.environ.get('COGNITO_CLIENT_ID')
 COGNITO_USER_POOL_DOMAIN = os.environ.get('COGNITO_USER_POOL_DOMAIN')
 
 
-def create_jwt_claims():
+def create_jwt_access_claims():
     return {
         "sub": "51b661cf-4109-4616-b7a5-178daf51fc12",
         "cognito:groups": [
@@ -32,22 +33,37 @@ def create_jwt_claims():
 
 def create_jwt_id_claims():
     return {
-        "custom:idp_username": "TEST_USER"
+        "sub": "e8c217e4-2c0e-45b6-9c5a-fff43c60c3ff",
+        "cognito:groups": [ "FOM_REVIEWER" ],
+        "custom:idp_name": "idir",
+        "iss": "https://cognito-idp.ca-central-1.amazonaws.com/ca-central-1_yds9Vci8g",
+        "cognito:username": "dev-idir_e72a12c916a44a9581cf39e5dcdffae7@idir",
+        "nonce": "APBEWsGN2ke1UCEiBrHGD1dNjXiU6rym-SCSm8UaQwaiqP5py5dML8fimxPiqEHLznhQrVTZ2bf1pMtrBxdKpKIwSG0WwGlpjj9eqsEEAq2v-weHTFxLgHep_VuWkPVIhCTRhpYPViy0An7hD0gqj7CUVzsEfAnFxpwocvKOqX8",
+        "custom:idp_user_id": "E72A12C916A44A9581CF39E5DCDFFAE7",
+        "origin_jti": "3658423e-c74a-4610-96c2-fb81abd0566a",
+        "aud": "6c9ieu27ik29mq75jeb7rrbdls",
+        "custom:idp_username": "IANLIU",
+        "token_use": "id",
+        "auth_time": time.time(),
+        "custom:idp_display_name": "Liu, Ian WLRS:EX",
+        "exp": time.time() + 60000,
+        "iat": time.time(),
+        "jti": "0945ff00-74a0-401e-83a6-5f8049655186",
+        "email": "ian.liu@gov.bc.ca"
     }
-
 
 def create_jwt_id_token(test_rsa_key,
                         claims=create_jwt_id_claims(),
-                        test_algorithm='RS256',
+                        test_algorithm="RS256",
                         test_headers={"kid": "12345"}):
     return jws.sign(claims, test_rsa_key, algorithm=test_algorithm,
                     headers=test_headers)
 
 
-def create_jwt_token(test_rsa_key,
-                     claims=create_jwt_claims(),
-                     test_algorithm='RS256',
-                     test_headers={"kid": "12345"}):
+def create_jwt_access_token(test_rsa_key,
+                            claims=create_jwt_access_claims(),
+                            test_algorithm='RS256',
+                            test_headers={"kid": "12345"}):
     return jws.sign(claims, test_rsa_key, algorithm=test_algorithm,
                     headers=test_headers)
 
@@ -58,9 +74,7 @@ def assert_error_response(response, http_error_code, error_code_string):
     assert error_detail_code == error_code_string, f"Expected error detail.code {error_code_string} but received {error_detail_code}"
 
 
-def headers(token):
+def headers(id_token, access_token):
+    # python str() to single quote, need to enclose it to double quote JSON standard string.
+    token = str({"id_token": id_token, "access_token": access_token}).replace("'", "\"")
     return {"Authorization": f"Bearer {token}"}
-
-
-def headers_with_id_token(token, id_token):
-    return {"Authorization": f"Bearer {token}", "id-token": id_token}

--- a/server/backend/tests/router/test_router_application.py
+++ b/server/backend/tests/router/test_router_application.py
@@ -15,11 +15,16 @@ class ClientAndAppID(TypedDict):
 
 
 def test_get_fam_application_nodata(
-    test_client_fixture: starlette.testclient.TestClient, test_rsa_key
+    test_client_fixture: starlette.testclient.TestClient,
+    test_rsa_key,
+    test_id_token
 ):
 
-    token = jwt_utils.create_jwt_token(test_rsa_key)
-    response = test_client_fixture.get(f"{endPoint}", headers=jwt_utils.headers(token))
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key)
+    response = test_client_fixture.get(
+        f"{endPoint}",
+        headers=jwt_utils.headers(test_id_token, access_token)
+    )
 
     LOGGER.debug(f"endPoint: {endPoint}")
     LOGGER.debug(f"response {response}")
@@ -32,10 +37,14 @@ def test_get_fam_application_nodata(
 def test_get_fam_application(
     client_application: starlette.testclient.TestClient,
     test_rsa_key,
+    test_id_token,
     application_dict: Dict[str, Union[str, datetime.datetime]],
 ):
-    token = jwt_utils.create_jwt_token(test_rsa_key)
-    response = client_application.get(f"{endPoint}", headers=jwt_utils.headers(token))
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key)
+    response = client_application.get(
+        f"{endPoint}",
+        headers=jwt_utils.headers(test_id_token, access_token)
+    )
 
     LOGGER.debug(f"response: {response}")
     data = response.json()
@@ -49,7 +58,8 @@ def test_get_fam_application_roles(
     application_dict: Dict[str, Union[str, datetime.datetime]],
     concrete_role_dict,
     concrete_role2_dict,
-    test_rsa_key
+    test_rsa_key,
+    test_id_token
 ):
     client = application_roles["client"]
     app_id = application_roles["app_id"]
@@ -58,8 +68,11 @@ def test_get_fam_application_roles(
     role_end_point = endPoint + f"/{app_id}/fam_roles"
     LOGGER.debug(f"role_end_point: {role_end_point}")
 
-    token = jwt_utils.create_jwt_token(test_rsa_key)
-    resp = client.get(role_end_point, headers=jwt_utils.headers(token))
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key)
+    resp = client.get(
+        role_end_point,
+        headers=jwt_utils.headers(test_id_token, access_token)
+    )
     LOGGER.debug(f"resp status: {resp.status_code}")
     resp_data = resp.json()
     LOGGER.debug(f"resp data as JSON: {resp.text}")
@@ -90,7 +103,8 @@ def test_get_fam_user_role_assignment(
     concrete_role2_dict,
     abstract_role_data,
     user_data_dict,
-    test_rsa_key
+    test_rsa_key,
+    test_id_token
 ):
 
     client = application_role_assignment["client"]
@@ -98,8 +112,11 @@ def test_get_fam_user_role_assignment(
 
     role_end_point = endPoint + f"/{app_id}/user_role_assignment"
 
-    token = jwt_utils.create_jwt_token(test_rsa_key)
-    resp = client.get(role_end_point, headers=jwt_utils.headers(token))
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key)
+    resp = client.get(
+        role_end_point,
+        headers=jwt_utils.headers(test_id_token, access_token)
+    )
     role_assignments = resp.json()
     LOGGER.debug(f"resp data: {role_assignments}")
     LOGGER.debug(f"json str: {resp.text}")

--- a/server/backend/tests/router/test_router_userRoleAssignment.py
+++ b/server/backend/tests/router/test_router_userRoleAssignment.py
@@ -36,17 +36,17 @@ def test_create_user_role_assignment_associated_with_abstract_role(
     request_data = copy.deepcopy(user_role_dict)
     request_data["role_id"] = fom_submitter_role.role_id
 
-    claims = jwt_utils.create_jwt_claims()
+    claims = jwt_utils.create_jwt_access_claims()
     id_claims = jwt_utils.create_jwt_id_claims()
     claims[jwt_validation.JWT_GROUPS_KEY] = "FOM_ACCESS_ADMIN"
-    token = jwt_utils.create_jwt_token(test_rsa_key, claims)
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key, claims)
     id_token = jwt_utils.create_jwt_id_token(test_rsa_key, id_claims)
 
     # Execute POST (concrete role created for role assignment and linked to parent role)
     response = test_client_fixture.post(
         f"{endPoint}",
         json=request_data,
-        headers=jwt_utils.headers_with_id_token(token, id_token)
+        headers=jwt_utils.headers(id_token, access_token)
     )
 
     # Verify status and body
@@ -103,17 +103,17 @@ def test_create_user_role_assignment_with_concrete_role(
     request_data["role_id"] = role_db_item.role_id
     del request_data["forest_client_number"]
 
-    claims = jwt_utils.create_jwt_claims()
+    claims = jwt_utils.create_jwt_access_claims()
     token_id_claims = jwt_utils.create_jwt_id_claims()
     claims[jwt_validation.JWT_GROUPS_KEY] = "FOM_ACCESS_ADMIN"
-    token = jwt_utils.create_jwt_token(test_rsa_key, claims)
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key, claims)
     id_token_header = jwt_utils.create_jwt_id_token(test_rsa_key, token_id_claims)
 
     # Execute POST (role assignment created)
     response = test_client_fixture.post(
         f"{endPoint}",
         json=request_data,
-        headers=jwt_utils.headers_with_id_token(token, id_token_header)
+        headers=jwt_utils.headers(id_token_header, access_token)
     )
 
     # Verify status and body
@@ -148,7 +148,7 @@ def test_create_user_role_assignment_with_concrete_role(
 
 
 def test_delete_user_role_assignment(
-    test_client_fixture, dbsession_user_role_assignment, test_rsa_key
+    test_client_fixture, dbsession_user_role_assignment, test_rsa_key, test_id_token
 ):
     db = dbsession_user_role_assignment
 
@@ -158,14 +158,14 @@ def test_delete_user_role_assignment(
     ).all()
     assert len(user_role_assignment_db_items) == 1
 
-    claims = jwt_utils.create_jwt_claims()
+    claims = jwt_utils.create_jwt_access_claims()
     claims[jwt_validation.JWT_GROUPS_KEY] = "FOM_ACCESS_ADMIN"
-    token = jwt_utils.create_jwt_token(test_rsa_key, claims)
+    access_token = jwt_utils.create_jwt_access_token(test_rsa_key, claims)
 
     # Execute Delete
     test_client_fixture.delete(
         f"{endPoint}/{user_role_assignment_db_items[0].user_role_xref_id}",
-        headers=jwt_utils.headers(token)
+        headers=jwt_utils.headers(test_id_token, access_token)
     )
 
     # Verify user/role assignment has been deleted


### PR DESCRIPTION
This is a quick fix for issue encountered on DEV for previous PR change that used "id-token" header to set id token and AWS server throw error for "id-token is not allowed by Access-Control-Allow-Headers in preflight response".

How to configure "Access-Control-Allow-Headers" on AWS is still not known and this is alternative quick solution to change code to make our app works.

- Combine access_token with id_token in the 'Bearer' Authorization header to pass to backend.
- Backend quick change to parse received token into access_token and id_token.
- Due to this change, almost every endpoint/jwt tests failed (for fixture used) and tests are fixed.