### PR TITLE
Feat/367 save user (API Requester) with cognito user

### DIFF
--- a/server/backend/api/app/constants.py
+++ b/server/backend/api/app/constants.py
@@ -20,5 +20,7 @@ class AppEnv(str, Enum):
 
 FAM_PROXY_API_USER = "fam_proxy_api"
 
+COGNITO_USERNAME_KEY = "username"
+
 # TODO: Only uses this before forest-client api integration from front-end.
 DUMMY_FOREST_CLIENT_NAME = "DUMMY_FOREST_CLIENT_NAME"

--- a/server/backend/api/app/crud/crud_forest_client.py
+++ b/server/backend/api/app/crud/crud_forest_client.py
@@ -33,7 +33,7 @@ def create_forest_client(fam_forest_client: schemas.FamForestClientCreate, db: S
     return db_item
 
 
-def find_or_create(db: Session, forest_client_number: str):
+def find_or_create(db: Session, forest_client_number: str, requester: str):
     LOGGER.debug(
         "Forest Client - 'find_or_create' with forest_client_number: "
         f"{forest_client_number}."
@@ -49,8 +49,7 @@ def find_or_create(db: Session, forest_client_number: str):
         request_forest_client = schemas.FamForestClientCreate(
             **{
                 "forest_client_number": forest_client_number,
-                #"client_name": client_name,
-                "create_user": famConstants.FAM_PROXY_API_USER,
+                "create_user": requester,
             }
         )
         fam_forest_client = create_forest_client(request_forest_client, db)

--- a/server/backend/api/app/crud/crud_role.py
+++ b/server/backend/api/app/crud/crud_role.py
@@ -56,7 +56,7 @@ def create_role(role: schemas.FamRoleCreate, db: Session) -> models.FamRole:
                 "forest_client_number": forest_client_number,
                 "client_name": "going to delete anyways when complete issue"
                 + f" 327 / {forest_client_number}",
-                "create_user": constants.FAM_PROXY_API_USER,
+                "create_user": fam_role_model.create_user,
             }
             fc_pydantic = schemas.FamForestClientCreate(**fc_dict)
             forest_client_model = crud_forest_client.create_forest_client(

--- a/server/backend/api/app/crud/crud_user.py
+++ b/server/backend/api/app/crud/crud_user.py
@@ -97,7 +97,11 @@ def delete_user(db: Session, user_id: int):
     return fam_user
 
 
-def find_or_create(db: Session, user_type_code: str, user_name: str):
+def find_or_create(
+        db: Session,
+        user_type_code: str,
+        user_name: str,
+        requester: str):
     LOGGER.debug(
         f"User - 'find_or_create' with user_type: {user_type_code}, " +
         f"user_name: {user_name}."
@@ -109,7 +113,7 @@ def find_or_create(db: Session, user_type_code: str, user_name: str):
             **{
                 "user_type_code": user_type_code,
                 "user_name": user_name,
-                "create_user": famConstants.FAM_PROXY_API_USER,
+                "create_user": requester,
             }
         )
         fam_user = create_user(request_user, db)

--- a/server/backend/api/app/jwt_validation.py
+++ b/server/backend/api/app/jwt_validation.py
@@ -8,6 +8,8 @@ from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2AuthorizationCodeBearer
 from jose import jwt
 
+from api.app.constants import COGNITO_USERNAME_KEY
+
 # think that just importing config then access through its namespace makes code
 # easier to understand, ie:
 # import config
@@ -228,3 +230,9 @@ def authorize_by_app_id(
 def get_access_roles(claims: dict = Depends(authorize)):
     groups = claims[JWT_GROUPS_KEY]
     return groups
+
+
+def get_request_username(claims: dict = Depends(authorize)):
+    requester = claims[COGNITO_USERNAME_KEY]
+    LOGGER.debug(f"Current requester for API: {requester}")
+    return requester

--- a/server/backend/api/app/routers/router_user_role_assignment.py
+++ b/server/backend/api/app/routers/router_user_role_assignment.py
@@ -16,7 +16,8 @@ router = APIRouter()
 def create_user_role_assignment(
     role_assignment_request: schemas.FamUserRoleAssignmentCreate,
     db: Session = Depends(database.get_db),
-    token_claims: dict = Depends(jwt_validation.authorize)
+    token_claims: dict = Depends(jwt_validation.authorize),
+    requester: str = Depends(jwt_validation.get_request_username)
 ):
     """
     Create FAM user_role_xref association.
@@ -29,7 +30,7 @@ def create_user_role_assignment(
     jwt_validation.authorize_by_app_id(application_id, db, token_claims)
 
     create_data = crud_user_role.create_user_role(
-        db, role_assignment_request
+        db, role_assignment_request, requester
     )
     LOGGER.debug(
         "User/Role assignment executed successfully, "
@@ -41,7 +42,8 @@ def create_user_role_assignment(
 @router.delete(
     "/{user_role_xref_id}",
     status_code=HTTPStatus.NO_CONTENT,
-    response_class=Response
+    response_class=Response,
+    dependencies=[Depends(jwt_validation.get_request_username)]
 )
 def delete_user_role_assignment(
     user_role_xref_id: int,

--- a/server/backend/tests/crud/test_crud_user_role_assignment.py
+++ b/server/backend/tests/crud/test_crud_user_role_assignment.py
@@ -53,7 +53,7 @@ def test_role_not_exist_raise_exception(
 
     with pytest.raises(HTTPException) as e:
         assert crud_user_role.create_user_role(
-            db, user_role_assignment_model
+            db, user_role_assignment_model, constants.FAM_PROXY_API_USER
         )
     LOGGER.debug(f"Expected exception raised: {str(e._excinfo)}")
     assert str(e._excinfo).find("Role id ") != -1
@@ -89,7 +89,7 @@ def test_user_role_assignment_with_abstract_role_raise_exception(
     del invalid_request.forest_client_number
 
     with pytest.raises(HTTPException) as e:
-        assert crud_user_role.create_user_role(db, invalid_request)
+        assert crud_user_role.create_user_role(db, invalid_request, constants.FAM_PROXY_API_USER)
     LOGGER.debug(f"Expected exception raised: {str(e._excinfo)}")
     assert str(e._excinfo).find("Cannot assign") != -1
     db.rollback()
@@ -119,7 +119,7 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter(  # NOSONAR
 
     # User/Role assignment created.
     user_role_assignment = crud_user_role.create_user_role(
-        db, user_role_assignment_model
+        db, user_role_assignment_model, constants.FAM_PROXY_API_USER
     )
 
     # Find child role
@@ -165,13 +165,13 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter_twice_raise
 
     # User/Role assignment created.
     user_role_assignment1 = crud_user_role.create_user_role(
-        db, user_role_assignment_model
+        db, user_role_assignment_model, constants.FAM_PROXY_API_USER
     )
 
     # Call create twice with the same request.
     with pytest.raises(HTTPException) as e:
         crud_user_role.create_user_role(
-            db, user_role_assignment_model
+            db, user_role_assignment_model, constants.FAM_PROXY_API_USER
         )
 
     LOGGER.debug(f"Expected exception raised: {str(e._excinfo)}")

--- a/server/flyway/sql/V22__create_and_update_user_length_increase.sql
+++ b/server/flyway/sql/V22__create_and_update_user_length_increase.sql
@@ -1,0 +1,43 @@
+-- Running upgrade V21 -> V22
+
+-- Increase create_user and update_user to (60)
+
+ALTER TABLE app_fam.fam_application
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_application_client
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_application_group_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_forest_client
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_group
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_group_role_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_role
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_user
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_user_group_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);
+
+ALTER TABLE app_fam.fam_user_role_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(60),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(60);


### PR DESCRIPTION
This PR contains:
- extracts "username" from access_token claim as a requester to API. This is Cognito's user id.
- obtains "requester" (username) as router "Depends".
- saves API requester into db various tables' create_user field.
- Flyway script v22 to increase create_user/update_user length for saving this Cognito user id.