### PR TITLE
Feat/453: Onboard SPAR

### DIFF
--- a/.github/workflows/reusable_auth_function_ci.yml
+++ b/.github/workflows/reusable_auth_function_ci.yml
@@ -49,6 +49,9 @@ jobs:
           FLYWAY_PLACEHOLDERS_client_id_dev_fom_oidc_client: 1a8pkq0psq0daj5e6ir3ppcjkj
           FLYWAY_PLACEHOLDERS_client_id_test_fom_oidc_client: 7b6eki43nahus9ca0lhjs6m568
           FLYWAY_PLACEHOLDERS_client_id_prod_fom_oidc_client: 1rhdfiek5ntmk2kg39d6e31p46
+          FLYWAY_PLACEHOLDERS_client_id_dev_spar_oidc_client: xxqiHFmwG8j1cVAz7NgtknaZOt
+          FLYWAY_PLACEHOLDERS_client_id_test_spar_oidc_client: dm5Xkmomnq0gbwBiXiN5LgAna2
+          FLYWAY_PLACEHOLDERS_client_id_prod_spar_oidc_client: KdnD2eGS3Zcx494p04yMFhDwSf
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,9 @@ services:
       - FLYWAY_PLACEHOLDERS_client_id_dev_fom_oidc_client=1a8pkq0psq0daj5e6ir3ppcjkj
       - FLYWAY_PLACEHOLDERS_client_id_test_fom_oidc_client=7b6eki43nahus9ca0lhjs6m568
       - FLYWAY_PLACEHOLDERS_client_id_prod_fom_oidc_client=1rhdfiek5ntmk2kg39d6e31p46
+      - FLYWAY_PLACEHOLDERS_client_id_dev_spar_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZOt
+      - FLYWAY_PLACEHOLDERS_client_id_test_spar_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAna2
+      - FLYWAY_PLACEHOLDERS_client_id_prod_spar_oidc_client=KdnD2eGS3Zcx494p04yMFhDwSf
 
     depends_on:
       fam-database:

--- a/infrastructure/server/flyway.tf
+++ b/infrastructure/server/flyway.tf
@@ -148,7 +148,10 @@ data "aws_lambda_invocation" "invoke_flyway_migration" {
           "client_id_fom_ministry" : "nolongerinuse2",
           "client_id_dev_fom_oidc_client" : "${aws_cognito_user_pool_client.dev_fom_oidc_client.id}",
           "client_id_test_fom_oidc_client" : "${aws_cognito_user_pool_client.test_fom_oidc_client.id}",
-          "client_id_prod_fom_oidc_client" : "${aws_cognito_user_pool_client.prod_fom_oidc_client.id}"
+          "client_id_prod_fom_oidc_client" : "${aws_cognito_user_pool_client.prod_fom_oidc_client.id}",
+          "client_id_dev_spar_oidc_client" : "${aws_cognito_user_pool_client.dev_spar_oidc_client.id}",
+          "client_id_test_spar_oidc_client" : "${aws_cognito_user_pool_client.test_spar_oidc_client.id}",
+          "client_id_prod_spar_oidc_client" : "${aws_cognito_user_pool_client.prod_spar_oidc_client.id}"
         },
         "target": "latest"
     },
@@ -169,6 +172,9 @@ data "aws_lambda_invocation" "invoke_flyway_migration" {
     aws_cognito_user_pool_client.dev_fom_oidc_client,
     aws_cognito_user_pool_client.test_fom_oidc_client,
     aws_cognito_user_pool_client.prod_fom_oidc_client,
+    aws_cognito_user_pool_client.dev_spar_oidc_client,
+    aws_cognito_user_pool_client.test_spar_oidc_client,
+    aws_cognito_user_pool_client.prod_spar_oidc_client,
   ]
 
   count = var.execute_flyway ? 1 : 0

--- a/infrastructure/server/oidc_clients_spar.tf
+++ b/infrastructure/server/oidc_clients_spar.tf
@@ -1,0 +1,105 @@
+resource "aws_cognito_user_pool_client" "dev_spar_oidc_client" {
+  access_token_validity                         = "5"
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = "true"
+  allowed_oauth_scopes                          = ["openid", "profile", "email"]
+  callback_urls                                 = [
+    "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/",
+    "http://localhost:3000/dashboard",
+    "http://localhost:3000/silent-check-sso"
+  ]
+  logout_urls                                   = [
+    "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/",
+    "http://localhost:3000/"
+  ]
+  enable_propagate_additional_user_context_data = "false"
+  enable_token_revocation                       = "true"
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  id_token_validity                             = "60"
+  name                                          = "spar_dev"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = "${concat(var.minimum_read_list, ["custom:idp_display_name"])}"
+  refresh_token_validity                        = "24"
+  supported_identity_providers                  = [
+    "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
+    "${aws_cognito_identity_provider.dev_bceid_business_oidc_provider.provider_name}"
+  ]
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "hours"
+  }
+
+  user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
+  write_attributes = "${concat(var.minimum_write_list, ["custom:idp_display_name"])}"
+}
+
+resource "aws_cognito_user_pool_client" "test_spar_oidc_client" {
+  access_token_validity                         = "5"
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = "true"
+  allowed_oauth_scopes                          = ["openid", "profile", "email"]
+  callback_urls                                 = [
+    "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/",
+    "https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/dashboard"
+  ]
+  logout_urls                                   = [
+    "https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/"
+  ]
+  enable_propagate_additional_user_context_data = "false"
+  enable_token_revocation                       = "true"
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  id_token_validity                             = "60"
+  name                                          = "spar_test"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = "${concat(var.minimum_read_list, ["custom:idp_display_name"])}"
+  refresh_token_validity                        = "24"
+  supported_identity_providers                  = [
+    "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
+    "${aws_cognito_identity_provider.test_bceid_business_oidc_provider.provider_name}"
+  ]
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "hours"
+  }
+
+  user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
+  write_attributes = "${concat(var.minimum_write_list, ["custom:idp_display_name"])}"
+}
+
+resource "aws_cognito_user_pool_client" "prod_spar_oidc_client" {
+  access_token_validity                         = "5"
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = "true"
+  allowed_oauth_scopes                          = ["openid", "profile", "email"]
+  callback_urls                                 = [
+    "https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/dashboard"
+  ]
+  logout_urls                                   = [
+    "https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/"
+  ]
+  enable_propagate_additional_user_context_data = "false"
+  enable_token_revocation                       = "true"
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  id_token_validity                             = "60"
+  name                                          = "spar_prod"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = "${concat(var.minimum_read_list, ["custom:idp_display_name"])}"
+  refresh_token_validity                        = "24"
+  supported_identity_providers                  = [
+    "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
+    "${aws_cognito_identity_provider.prod_bceid_business_oidc_provider.provider_name}"
+  ]
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "hours"
+  }
+
+  user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
+  write_attributes = "${concat(var.minimum_write_list, ["custom:idp_display_name"])}"
+}

--- a/server/backend/testspg/crud/test_crud_application.py
+++ b/server/backend/testspg/crud/test_crud_application.py
@@ -9,14 +9,14 @@ from api.app.crud import crud_application
 
 def test_get_applications(dbPgSession: sessionmaker):
     apps = crud_application.get_applications(db=dbPgSession)
-    assert len(apps) == 4
+    assert len(apps) == 7
     assert hasattr(apps[0], "application_name")
     assert apps[0].application_name == "FAM"
 
 
 def test_get_application(dbPgSession: sessionmaker):
     apps = crud_application.get_applications(db=dbPgSession)
-    assert len(apps) == 4
+    assert len(apps) > 1
     for app in apps:
         app_by_id = crud_application.get_application(
             db=dbPgSession, application_id=app.application_id
@@ -26,7 +26,7 @@ def test_get_application(dbPgSession: sessionmaker):
 
 def test_get_application_by_name(dbPgSession: sessionmaker):
     apps = crud_application.get_applications(db=dbPgSession)
-    assert len(apps) == 4
+    assert len(apps) > 1
     for app in apps:
         app_by_name = crud_application.get_application_by_name(
             db=dbPgSession, application_name=app.application_name

--- a/server/flyway/sql/V23__create_spar_application.sql
+++ b/server/flyway/sql/V23__create_spar_application.sql
@@ -3,8 +3,8 @@ INSERT INTO app_fam.fam_application (
     application_name,
     application_description,
     app_environment,
-    update_user,
-    update_date
+    create_user,
+    create_date
 )
 VALUES ('SPAR_DEV', 'Seed Planning and Registry Application (DEV)', 'DEV', CURRENT_USER, CURRENT_DATE),
        ('SPAR_TEST', 'Seed Planning and Registry Application (TEST)', 'TEST', CURRENT_USER, CURRENT_DATE),
@@ -21,9 +21,9 @@ INSERT INTO app_fam.fam_role (
     create_user,
     create_date
 )
-VALUES ('SPAR_DEV_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (DEV)', (select application_id from app_fam.fam_application where application_name = 'SPAR_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('SPAR_TEST_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (TEST)', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('SPAR_PROD_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (PROD)', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE)
+VALUES ('SPAR_DEV_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (DEV)', (select application_id from app_fam.fam_application where application_name = 'FAM'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('SPAR_TEST_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (TEST)', (select application_id from app_fam.fam_application where application_name = 'FAM'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('SPAR_PROD_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (PROD)', (select application_id from app_fam.fam_application where application_name = 'FAM'), 'C', CURRENT_USER, CURRENT_DATE)
 ;
 
 
@@ -41,7 +41,7 @@ VALUES ('USER_WRITE', 'A role used by SPAR for manual testing', (select applicat
        ('USER_WRITE', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
        ('USER_READ', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
        ('USER_WRITE', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('USER_READ', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('USER_READ', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE)
 ;
 
 

--- a/server/flyway/sql/V23__create_spar_application.sql
+++ b/server/flyway/sql/V23__create_spar_application.sql
@@ -1,0 +1,58 @@
+-- Create spar_dev, spar_test and spar_prod applications
+INSERT INTO app_fam.fam_application (
+    application_name,
+    application_description,
+    app_environment,
+    update_user,
+    update_date
+)
+VALUES ('SPAR_DEV', 'Seed Planning and Registry Application (DEV)', 'DEV', CURRENT_USER, CURRENT_DATE),
+       ('SPAR_TEST', 'Seed Planning and Registry Application (TEST)', 'TEST', CURRENT_USER, CURRENT_DATE),
+       ('SPAR_PROD', 'Seed Planning and Registry Application (PROD)', 'PROD', CURRENT_USER, CURRENT_DATE)
+;
+
+
+-- Create spar_dev, spar_test and spar_prod admin roles
+INSERT INTO app_fam.fam_role (
+    role_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('SPAR_DEV_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (DEV)', (select application_id from app_fam.fam_application where application_name = 'SPAR_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('SPAR_TEST_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (TEST)', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('SPAR_PROD_ACCESS_ADMIN', 'Provides the privilege to assign or unassign all roles for SPAR (PROD)', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE)
+;
+
+
+-- Create a SPAR_TESTER roles for spar_dev, spar_test and spar_prod applications
+INSERT INTO app_fam.fam_role (
+    role_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('USER_WRITE', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('USER_READ', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('USER_WRITE', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('USER_READ', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('USER_WRITE', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('USER_READ', 'A role used by SPAR for manual testing', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+;
+
+
+-- Create dev, test and prod clients for SPAR
+INSERT INTO app_fam.fam_application_client (
+    cognito_client_id,
+    application_id,
+    create_user,
+    create_date
+)
+VALUES ('${client_id_dev_spar_oidc_client}', (select application_id from app_fam.fam_application where application_name = 'SPAR_DEV'), CURRENT_USER, CURRENT_DATE),
+       ('${client_id_test_spar_oidc_client}', (select application_id from app_fam.fam_application where application_name = 'SPAR_TEST'), CURRENT_USER, CURRENT_DATE),
+       ('${client_id_prod_spar_oidc_client}', (select application_id from app_fam.fam_application where application_name = 'SPAR_PROD'), CURRENT_USER, CURRENT_DATE)
+;


### PR DESCRIPTION
- onboard spar, create spar oidc client in terraform
- add spar application, application client for all env, spar admin role for all env, and two testing roles "user_write" and "user_read" (got from SPAR team) for all env in db
- update flyway infrastructure to pass cognito spar client id
- update pipeline and docker-compose to put flyway placeholder for the spar client id, just random strings
- update the test that gets all applications, update the asset number when we add apps