### PR TITLE
fix: #516 Duplicate and Environment Conflict when Creating Role Assignment in PROD for FOM TEST for Client

### DIFF
--- a/server/backend/api/app/constants.py
+++ b/server/backend/api/app/constants.py
@@ -22,5 +22,11 @@ FAM_PROXY_API_USER = "fam_proxy_api"
 
 COGNITO_USERNAME_KEY = "username"
 
+FOM_SUBMITTER_ROLE_NAME = "FOM_Submitter"
+FOM_APP_DESC = "Forest Operations Map"
+FOM_ROLE_PURPOSE = "Grant a user access to submit to FOM"
+FOM_APP_DEV_NAME = "fom_dev"
+FOM_APP_TEST_NAME = "fom_test"
+
 # TODO: Only uses this before forest-client api integration from front-end.
 DUMMY_FOREST_CLIENT_NAME = "DUMMY_FOREST_CLIENT_NAME"

--- a/server/backend/api/app/constants.py
+++ b/server/backend/api/app/constants.py
@@ -21,12 +21,3 @@ class AppEnv(str, Enum):
 FAM_PROXY_API_USER = "fam_proxy_api"
 
 COGNITO_USERNAME_KEY = "username"
-
-FOM_SUBMITTER_ROLE_NAME = "FOM_Submitter"
-FOM_APP_DESC = "Forest Operations Map"
-FOM_ROLE_PURPOSE = "Grant a user access to submit to FOM"
-FOM_APP_DEV_NAME = "fom_dev"
-FOM_APP_TEST_NAME = "fom_test"
-
-# TODO: Only uses this before forest-client api integration from front-end.
-DUMMY_FOREST_CLIENT_NAME = "DUMMY_FOREST_CLIENT_NAME"

--- a/server/backend/api/app/crud/crud_role.py
+++ b/server/backend/api/app/crud/crud_role.py
@@ -76,13 +76,20 @@ def create_role(role: schemas.FamRoleCreate, db: Session) -> models.FamRole:
     return fam_role_model
 
 
-def get_role_by_role_name(db: Session, role_name: str) -> Optional[models.FamRole]:
+def get_role_by_role_name_and_app_id(
+        db: Session,
+        role_name: str,
+        application_id: int
+) -> Optional[models.FamRole]:
     """
-    Gets FAM roles by unique role_name
+    Gets FAM role based on role_name and application_id.
     """
-    LOGGER.debug(f"Getting FamRole by role_name: {role_name}")
+    LOGGER.debug(f"Getting FamRole by role_name: {role_name} and application_di: {application_id}")
     return (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == role_name)
+        .filter(
+            models.FamRole.role_name == role_name,
+            models.FamRole.application_id == application_id
+        )
         .one_or_none()
     )

--- a/server/backend/api/app/crud/crud_user_role.py
+++ b/server/backend/api/app/crud/crud_user_role.py
@@ -73,7 +73,10 @@ def create_user_role(
         # Note: current FSA design in the 'request body' contains a
         #     'forest_client_number' if it requires a child role.
         child_role = find_or_create_forest_client_child_role(
-            db, request.forest_client_number, fam_role, requester
+            db,
+            request.forest_client_number,
+            fam_role,
+            requester
         )
 
     # Role Id for associating with user
@@ -178,9 +181,10 @@ def find_or_create_forest_client_child_role(
         parent_role.role_name, forest_client_number
     )
     # Verify if Forest Client role (child role) exist
-    child_role = crud_role.get_role_by_role_name(
+    child_role = crud_role.get_role_by_role_name_and_app_id(
         db,
         forest_client_role_name,
+        parent_role.application_id
     )
     LOGGER.debug(
         "Forest Client child role for role_name "

--- a/server/backend/tests/tests/crud/test_crud_role.py
+++ b/server/backend/tests/tests/crud/test_crud_role.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import session
 from api.app import constants
+import tests.tests.test_constants as testConstants
 
 import api.app.models.model as model
 import api.app.schemas as schemas
@@ -182,7 +183,7 @@ def test_can_create_roles_with_same_name_different_applications(
         "role_name": role.role_name,
         "role_purpose": "Role Purpose for Second Role",
         "application_id": application_2_db_item.application_id,
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "role_type_code": constants.RoleType.ROLE_TYPE_CONCRETE,
     })
     role_2 = crud_role.create_role(role=role_2_pydantic, db=db)
@@ -218,7 +219,7 @@ def test_get_role_by_role_name_and_app_id(
     ))[0]
 
     roles: List[model.FamRole] = db.query(model.FamRole).filter(
-        model.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME
+        model.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME
     ).all()
     assert len(roles) == 2
     dev_fom_submitter_role: model.FamRole = list(filter(

--- a/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
@@ -2,11 +2,12 @@ import copy
 import logging
 from typing import List
 
+import api.app.constants as constants
 import api.app.schemas as schemas
 import pytest
+import tests.tests.test_constants as testConstants
 from api.app.crud import crud_role, crud_user, crud_user_role
 from api.app.models import model as models
-import api.app.constants as constants
 from fastapi import HTTPException
 from pydantic import ValidationError
 from sqlalchemy import bindparam, text
@@ -53,7 +54,7 @@ def test_role_not_exist_raise_exception(
 
     with pytest.raises(HTTPException) as e:
         assert crud_user_role.create_user_role(
-            db, user_role_assignment_model, constants.FAM_PROXY_API_USER
+            db, user_role_assignment_model, testConstants.FAM_PROXY_API_USER
         )
     LOGGER.debug(f"Expected exception raised: {str(e._excinfo)}")
     assert str(e._excinfo).find("Role id ") != -1
@@ -76,7 +77,7 @@ def test_user_role_assignment_with_abstract_role_raise_exception(
 
     fam_submitter_role = (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME)
+        .filter(models.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
     # Verify this role is 'abstract' first.
@@ -89,7 +90,7 @@ def test_user_role_assignment_with_abstract_role_raise_exception(
     del invalid_request.forest_client_number
 
     with pytest.raises(HTTPException) as e:
-        assert crud_user_role.create_user_role(db, invalid_request, constants.FAM_PROXY_API_USER)
+        assert crud_user_role.create_user_role(db, invalid_request, testConstants.FAM_PROXY_API_USER)
     LOGGER.debug(f"Expected exception raised: {str(e._excinfo)}")
     assert str(e._excinfo).find("Cannot assign") != -1
     db.rollback()
@@ -107,19 +108,19 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter(  # NOSONAR
     )
     fom_submitter_role = (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME)
+        .filter(models.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
     # Verify parent role exist first.
     assert isinstance(fom_submitter_role, models.FamRole)
-    assert fom_submitter_role.role_name == constants.FOM_SUBMITTER_ROLE_NAME
+    assert fom_submitter_role.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME
     assert fom_submitter_role.role_type_code == constants.RoleType.ROLE_TYPE_ABSTRACT
 
     user_role_assignment_model.role_id = fom_submitter_role.role_id
 
     # User/Role assignment created.
     user_role_assignment = crud_user_role.create_user_role(
-        db, user_role_assignment_model, constants.FAM_PROXY_API_USER
+        db, user_role_assignment_model, testConstants.FAM_PROXY_API_USER
     )
 
     # Find child role
@@ -154,24 +155,24 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter_twice_raise
 
     fam_submitter_role = (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME)
+        .filter(models.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
     # Verify parent role exist first.
     assert isinstance(fam_submitter_role, models.FamRole)
-    assert fam_submitter_role.role_name == constants.FOM_SUBMITTER_ROLE_NAME
+    assert fam_submitter_role.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME
 
     user_role_assignment_model.role_id = fam_submitter_role.role_id
 
     # User/Role assignment created.
     user_role_assignment1 = crud_user_role.create_user_role(
-        db, user_role_assignment_model, constants.FAM_PROXY_API_USER
+        db, user_role_assignment_model, testConstants.FAM_PROXY_API_USER
     )
 
     # Call create twice with the same request.
     with pytest.raises(HTTPException) as e:
         crud_user_role.create_user_role(
-            db, user_role_assignment_model, constants.FAM_PROXY_API_USER
+            db, user_role_assignment_model, testConstants.FAM_PROXY_API_USER
         )
 
     LOGGER.debug(f"Expected exception raised: {str(e._excinfo)}")
@@ -241,14 +242,14 @@ def test_create_user_role_on_different_environments_with_same_role_name_should_p
     fom_dev_submitter_role: models.FamRole = (
         db.query(models.FamRole)
         .filter(
-            models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
+            models.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME,
             models.FamRole.application_id == fom_dev_application.application_id)
         .one()
     )
     fom_test_submitter_role: models.FamRole = (
         db.query(models.FamRole)
         .filter(
-            models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
+            models.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME,
             models.FamRole.application_id == fom_test_application.application_id)
         .one()
     )
@@ -269,7 +270,7 @@ def test_create_user_role_on_different_environments_with_same_role_name_should_p
         forest_client_number=forest_client_number)
     # User/Role assignment created - dev.
     user_role_assignment_dev = crud_user_role.create_user_role(
-        db, user_role_assignment_dev_model, constants.FAM_PROXY_API_USER
+        db, user_role_assignment_dev_model, testConstants.FAM_PROXY_API_USER
     )
 
     user_role_assignment_test_model = schemas.FamUserRoleAssignmentCreate(
@@ -279,7 +280,7 @@ def test_create_user_role_on_different_environments_with_same_role_name_should_p
         forest_client_number=forest_client_number)
     # User/Role assignment created - test.
     user_role_assignment_test = crud_user_role.create_user_role(
-        db, user_role_assignment_test_model, constants.FAM_PROXY_API_USER
+        db, user_role_assignment_test_model, testConstants.FAM_PROXY_API_USER
     )
 
     assert user_role_assignment_dev.role_id != user_role_assignment_test.role_id

--- a/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
@@ -220,9 +220,9 @@ def test_given_invalid_id_when_delete_assignment_raise_exception(
 
 def test_create_user_role_on_different_environments_with_same_role_name_should_pass(
     dbsession_fam_user_types: session.Session,
-    dbsession_FOM_submitter_role_dev_test: session.Session
+    dbsession_fom_submitter_role_dev_test: session.Session
 ):
-    db = dbsession_FOM_submitter_role_dev_test
+    db = dbsession_fom_submitter_role_dev_test
     LOGGER.debug(
         "Creating forest client FOM Submitter user/role assignment in dev and test "
     )

--- a/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from typing import List
 
 import api.app.schemas as schemas
 import pytest
@@ -138,7 +139,7 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter(  # NOSONAR
     assert user.user_type_code == user_role_assignment_model.user_type_code
     assert forest_client_role.role_type_code == constants.RoleType.ROLE_TYPE_CONCRETE
 
-    clean_up_user_role_assignment(db, user_role_assignment)
+    clean_up_user_role_assignment(db, [user_role_assignment])
 
 
 def test_create_user_role_assignment_for_forest_client_FOM_submitter_twice_raises_exception( # noqa NOSONAR
@@ -178,7 +179,7 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter_twice_raise
     fam_roles = crud_role.get_roles(db)  # all db roles created.
     assert len(fam_roles) == 2
 
-    clean_up_user_role_assignment(db, user_role_assignment1)
+    clean_up_user_role_assignment(db, [user_role_assignment1])
 
 
 def test_given_valid_id_when_delete_assignment_then_user_role_assignment_is_deleted(  # noqa NOSONAR
@@ -217,39 +218,142 @@ def test_given_invalid_id_when_delete_assignment_raise_exception(
     assert str(e._excinfo).find("No row was found when one was required") != -1
 
 
-def clean_up_user_role_assignment(
-    db: session.Session, user_role_assignment: schemas.FamUserRoleAssignmentGet
+def test_create_user_role_on_different_environments_with_same_role_name_should_pass(
+    dbsession_fam_user_types: session.Session,
+    dbsession_FOM_submitter_role_dev_test: session.Session
 ):
-    # Delete fam_user_role_xref
-    stmt = text(
-        """
-        DELETE FROM fam_user_role_xref
-        WHERE user_role_xref_id = :user_role_xref_id
-        """
+    db = dbsession_FOM_submitter_role_dev_test
+    LOGGER.debug(
+        "Creating forest client FOM Submitter user/role assignment in dev and test "
     )
-    stmt = stmt.bindparams(
-        bindparam("user_role_xref_id", value=user_role_assignment.user_role_xref_id)
+    fom_dev_application: models.FamApplication = (
+        db.query(models.FamApplication)
+        .filter(
+            models.FamApplication.app_environment == constants.AppEnv.APP_ENV_TYPE_DEV)
+        .one()
     )
-    db.execute(stmt)
+    fom_test_application: models.FamApplication = (
+        db.query(models.FamApplication)
+        .filter(
+            models.FamApplication.app_environment == constants.AppEnv.APP_ENV_TYPE_TEST)
+        .one()
+    )
 
-    # Delete child role (db.delete(forest_client_role)).
-    stmt = text(
-        """
-        DELETE FROM fam_role
-        WHERE role_id = :role_id
-        """
+    fom_dev_submitter_role: models.FamRole = (
+        db.query(models.FamRole)
+        .filter(
+            models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME,
+            models.FamRole.application_id == fom_dev_application.application_id)
+        .one()
     )
-    stmt = stmt.bindparams(bindparam("role_id", value=user_role_assignment.role_id))
-    db.execute(stmt)
+    fom_test_submitter_role: models.FamRole = (
+        db.query(models.FamRole)
+        .filter(
+            models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME,
+            models.FamRole.application_id == fom_test_application.application_id)
+        .one()
+    )
 
-    # Then delete parent role
-    stmt = text(
-        """
-        DELETE FROM fam_role
-    """
+    # Verify parent role exist first.
+    assert fom_dev_submitter_role.application.app_environment == constants.AppEnv.APP_ENV_TYPE_DEV
+    assert fom_test_submitter_role.application.app_environment == constants.AppEnv.APP_ENV_TYPE_TEST
+    assert fom_dev_submitter_role.role_type_code == constants.RoleType.ROLE_TYPE_ABSTRACT
+    assert fom_test_submitter_role.role_type_code == constants.RoleType.ROLE_TYPE_ABSTRACT
+    assert fom_dev_submitter_role.role_id != fom_test_submitter_role.role_id
+
+    user_name = "user1"
+    forest_client_number = "00001001"
+    user_role_assignment_dev_model = schemas.FamUserRoleAssignmentCreate(
+        user_name=user_name,
+        user_type_code=constants.UserType.IDIR,
+        role_id=fom_dev_submitter_role.role_id,
+        forest_client_number=forest_client_number)
+    # User/Role assignment created - dev.
+    user_role_assignment_dev = crud_user_role.create_user_role(
+        db, user_role_assignment_dev_model, constants.FAM_PROXY_API_USER
     )
-    # stmt = stmt.bindparams(bindparam("role_id", value=user_role_assignment.role_id))  # noqa NOSONAR
-    db.execute(stmt)
+
+    user_role_assignment_test_model = schemas.FamUserRoleAssignmentCreate(
+        user_name=user_name,
+        user_type_code=constants.UserType.IDIR,
+        role_id=fom_test_submitter_role.role_id,
+        forest_client_number=forest_client_number)
+    # User/Role assignment created - test.
+    user_role_assignment_test = crud_user_role.create_user_role(
+        db, user_role_assignment_test_model, constants.FAM_PROXY_API_USER
+    )
+
+    assert user_role_assignment_dev.role_id != user_role_assignment_test.role_id
+    assert user_role_assignment_dev.user_id == user_role_assignment_test.user_id
+
+    fom_forest_client_role_dev: models.FamRole = (
+        db.query(models.FamRole)
+        .filter(
+            models.FamRole.role_id == user_role_assignment_dev.role_id)
+        .one()
+    )
+    assert fom_forest_client_role_dev.application_id == fom_dev_application.application_id
+    assert fom_forest_client_role_dev.role_type_code == constants.RoleType.ROLE_TYPE_CONCRETE
+    assert fom_forest_client_role_dev.parent_role_id == fom_dev_submitter_role.role_id
+
+    fom_forest_client_role_test: models.FamRole = (
+        db.query(models.FamRole)
+        .filter(
+            models.FamRole.role_id == user_role_assignment_test.role_id)
+        .one()
+    )
+    assert fom_forest_client_role_test.application_id == fom_test_application.application_id
+    assert fom_forest_client_role_test.role_type_code == constants.RoleType.ROLE_TYPE_CONCRETE
+    assert fom_forest_client_role_test.parent_role_id == fom_test_submitter_role.role_id
+
+    clean_up_user_role_assignment(db, [user_role_assignment_dev, user_role_assignment_test])
+
+
+def clean_up_user_role_assignment(
+    db: session.Session, user_role_assignments: List[schemas.FamUserRoleAssignmentGet]
+):
+    for user_role_assignment in user_role_assignments:
+
+        # Delete fam_user_role_xref
+        stmt = text(
+            """
+            DELETE FROM fam_user_role_xref
+            WHERE user_role_xref_id = :user_role_xref_id
+            """
+        )
+        stmt = stmt.bindparams(
+            bindparam("user_role_xref_id", value=user_role_assignment.user_role_xref_id)
+        )
+        db.execute(stmt)
+
+        role: models.FamRole = (
+            db.query(models.FamRole)
+            .filter(
+                models.FamRole.role_id == user_role_assignment.role_id)
+            .one()
+        )
+        parent_role_id = role.parent_role_id
+
+        # Delete child role (db.delete(forest_client_role)).
+        stmt = text(
+            """
+            DELETE FROM fam_role
+            WHERE role_id = :role_id
+            """
+        )
+        stmt = stmt.bindparams(bindparam("role_id", value=user_role_assignment.role_id))
+        db.execute(stmt)
+
+        # Then delete parent role
+        if parent_role_id is not None:
+            stmt = text(
+                """
+                DELETE FROM fam_role
+                WHERE role_id = :role_id
+                """
+            )
+            stmt = stmt.bindparams(bindparam("role_id", parent_role_id))
+            db.execute(stmt)
 
     # Delete user (db.delete(newUser))
     stmt = text(

--- a/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/crud/test_crud_user_role_assignment.py
@@ -12,7 +12,6 @@ from pydantic import ValidationError
 from sqlalchemy import bindparam, text
 from sqlalchemy.orm import session
 from sqlalchemy.orm.exc import NoResultFound
-from tests.fixtures.fixtures_crud_user_role_assignment import FOM_SUBMITTER_ROLE_NAME  # noqa
 
 LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +76,7 @@ def test_user_role_assignment_with_abstract_role_raise_exception(
 
     fam_submitter_role = (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME)
+        .filter(models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
     # Verify this role is 'abstract' first.
@@ -108,12 +107,12 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter(  # NOSONAR
     )
     fom_submitter_role = (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME)
+        .filter(models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
     # Verify parent role exist first.
     assert isinstance(fom_submitter_role, models.FamRole)
-    assert fom_submitter_role.role_name == FOM_SUBMITTER_ROLE_NAME
+    assert fom_submitter_role.role_name == constants.FOM_SUBMITTER_ROLE_NAME
     assert fom_submitter_role.role_type_code == constants.RoleType.ROLE_TYPE_ABSTRACT
 
     user_role_assignment_model.role_id = fom_submitter_role.role_id
@@ -155,12 +154,12 @@ def test_create_user_role_assignment_for_forest_client_FOM_submitter_twice_raise
 
     fam_submitter_role = (
         db.query(models.FamRole)
-        .filter(models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME)
+        .filter(models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
     # Verify parent role exist first.
     assert isinstance(fam_submitter_role, models.FamRole)
-    assert fam_submitter_role.role_name == FOM_SUBMITTER_ROLE_NAME
+    assert fam_submitter_role.role_name == constants.FOM_SUBMITTER_ROLE_NAME
 
     user_role_assignment_model.role_id = fam_submitter_role.role_id
 
@@ -242,14 +241,14 @@ def test_create_user_role_on_different_environments_with_same_role_name_should_p
     fom_dev_submitter_role: models.FamRole = (
         db.query(models.FamRole)
         .filter(
-            models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME,
+            models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
             models.FamRole.application_id == fom_dev_application.application_id)
         .one()
     )
     fom_test_submitter_role: models.FamRole = (
         db.query(models.FamRole)
         .filter(
-            models.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME,
+            models.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
             models.FamRole.application_id == fom_test_application.application_id)
         .one()
     )

--- a/server/backend/tests/tests/fixtures/fixtures_crud_application.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_application.py
@@ -1,15 +1,16 @@
 import datetime
 import logging
+from typing import Any, Dict, Iterator, Union
+
+import api.app.constants as constants
+import api.app.schemas as schemas
 import pytest
 import sqlalchemy
-from typing import Any, Dict, Union, Iterator
-
-import api.app.schemas as schemas
+import tests.tests.test_constants as testConstants
 from api.app.crud import crud_application as crud_application
 from api.app.crud import crud_role as crud_role
-from api.app.models import model as models
-import api.app.constants as constants
 from api.app.crud import crud_utils
+from api.app.models import model as models
 
 LOGGER = logging.getLogger(__name__)
 # TODO: look for application queries that retrieve the app_id and use the
@@ -64,7 +65,7 @@ def application_dict() -> Iterator[Dict[str, Union[str, datetime.datetime]]]:
         "application_name": "FAM",
         "application_description": "a really good app",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_DEV,
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
         "update_user": "Ron Duguey",
         "update_date": datetime.datetime.now(),
@@ -238,12 +239,12 @@ def dbsession_application_with_role_user_assignment(
     user_role_assignment = models.FamUserRoleXref(
         user_id=user_data_model.user_id,
         role_id=concrete_role_model.role_id,
-        create_user=constants.FAM_PROXY_API_USER,
+        create_user=testConstants.FAM_PROXY_API_USER,
     )
     user_role_assignment_nested = models.FamUserRoleXref(
         user_id=user_data_model.user_id,
         role_id=concrete_role2_model.role_id,
-        create_user=constants.FAM_PROXY_API_USER,
+        create_user=testConstants.FAM_PROXY_API_USER,
     )
 
     db.add(user_role_assignment)
@@ -305,28 +306,28 @@ def dbsession_different_envs_apps(
         "application_name": "FAM",
         "application_description": "Forests Access Management",
         "app_environment": None,
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     dev_fom_app = models.FamApplication(**{
         "application_name": "FOM_DEV",
         "application_description": "Forest Operations Map (DEV)",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_DEV,
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     test_fom_app = models.FamApplication(**{
         "application_name": "FOM_TEST",
         "application_description": "Forest Operations Map (TEST)",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_TEST,
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     prod_fom_app = models.FamApplication(**{
         "application_name": "FOM_PROD",
         "application_description": "Forest Operations Map (PROD)",
         "app_environment": constants.AppEnv.APP_ENV_TYPE_PROD,
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     })
     db.add(fam_app)

--- a/server/backend/tests/tests/fixtures/fixtures_crud_forestclient.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_forestclient.py
@@ -1,8 +1,9 @@
-import pytest
-from typing import Dict, Generator, Union, Iterator
 import logging
+from typing import Dict, Generator, Iterator, Union
+
+import pytest
+import tests.tests.test_constants as testConstants
 from api.app.models import model
-import api.app.constants as constants
 
 LOGGER = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ def forest_client_dict() -> Iterator[Dict[str, str]]:
     fc_dict = {
         "forest_client_number" : "00001101",
         #"client_name": "acme forestry",
-        "create_user": constants.FAM_PROXY_API_USER
+        "create_user": testConstants.FAM_PROXY_API_USER
         # TODO: should duplicate this pattern all through the tests for population of create_user, and think about making it the default way this field is populated in the app for all tables.
     }
     yield fc_dict

--- a/server/backend/tests/tests/fixtures/fixtures_crud_role.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_role.py
@@ -2,13 +2,13 @@ import datetime
 import logging
 from typing import Dict, Iterator, List, Union
 
-import pytest
-import sqlalchemy.exc
-from sqlalchemy.orm import session
-
 import api.app.constants as constants
 import api.app.models.model as model
 import api.app.schemas as schemas
+import pytest
+import sqlalchemy.exc
+import tests.tests.test_constants as testConstants
+from sqlalchemy.orm import session
 
 LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ def concrete_role_dict() -> Iterator[Dict[str, str]]:
         "role_name": "FAM_ADMIN",
         "role_purpose": "FAM Admin",
         "application_id": 99999,  # fake id, set it to test id in real testing code.
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "role_type_code": constants.RoleType.ROLE_TYPE_CONCRETE,
     }
     yield role_data
@@ -139,7 +139,7 @@ def concrete_role2_dict() -> Iterator[Dict[str, str]]:
     role_data = {
         "role_name": "FAM_TEST",
         "role_purpose": "FAM Testing",
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "role_type_code": constants.RoleType.ROLE_TYPE_CONCRETE,
     }
     yield role_data
@@ -156,7 +156,7 @@ def concrete_role_with_forest_client() -> Iterator[Dict[str, str]]:
     role_data = {
         "role_name": "FAM_TEST_FC",
         "role_purpose": "FAM Testing role with forest client",
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "role_type_code": constants.RoleType.ROLE_TYPE_CONCRETE,
         "forest_client_number": '00014903'
     }
@@ -176,7 +176,7 @@ def abstract_role_data() -> Iterator[Dict[str, str]]:
     role_data = {
         "role_name": "FAM_ABS_ROLE",
         "role_purpose": "FAM Testing abstract role",
-        "create_user": constants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "role_type_code": constants.RoleType.ROLE_TYPE_ABSTRACT,
     }
     yield role_data

--- a/server/backend/tests/tests/fixtures/fixtures_crud_user.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_user.py
@@ -1,12 +1,13 @@
 import datetime
 import logging
 import uuid
-from typing import TypedDict, Dict, Any, Union, Iterator
+from typing import Any, Dict, Iterator, TypedDict, Union
 
+import api.app.constants as famConstants
 import api.app.models.model as model
 import api.app.schemas as schemas
-import api.app.constants as famConstants
 import pytest
+import tests.tests.test_constants as testConstants
 from api.app.crud import crud_group as crud_group
 from sqlalchemy.orm import session
 
@@ -96,7 +97,7 @@ def user_data3_dict() -> Iterator[Dict[str, Union[str, famConstants.UserType]]]:
         "cognito_user_id": "zzff",
         "user_name": "BSMITH",
         "user_guid": str(uuid.uuid4()),
-        "create_user": famConstants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
     }
     # return user_data
     # try return instead? yield user_data
@@ -172,9 +173,9 @@ def user_data_dict() -> Iterator[Dict[str, Union[str, datetime.datetime]]]:
         "cognito_user_id": "22ftw",
         "user_name": "MBOSSY",
         "user_guid": str(uuid.uuid4()),
-        "create_user": famConstants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
-        "update_user": famConstants.FAM_PROXY_API_USER,
+        "update_user": testConstants.FAM_PROXY_API_USER,
         "update_date": datetime.datetime.now(),
     }
     yield user_data
@@ -195,9 +196,9 @@ def user_data2_dict() -> Iterator[FamUserTD]:
         "cognito_user_id": "22dfs",
         "user_name": "DPOTVIN",
         "user_guid": str(uuid.uuid4()),
-        "create_user": famConstants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
-        "update_user": famConstants.FAM_PROXY_API_USER,
+        "update_user": testConstants.FAM_PROXY_API_USER,
         "update_date": datetime.datetime.now(),
     }
     yield user_data
@@ -207,9 +208,9 @@ def user_data2_dict() -> Iterator[FamUserTD]:
 def user_group_xref_dict() -> Iterator[Dict[str, Union[datetime.datetime, str]]]:
     nowdatetime = datetime.datetime.now()
     x_ref_data = {
-        "create_user": famConstants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": nowdatetime,
-        "update_user": famConstants.FAM_PROXY_API_USER,
+        "update_user": testConstants.FAM_PROXY_API_USER,
         "update_date": nowdatetime,
     }
     yield x_ref_data
@@ -232,7 +233,7 @@ def group_dict() -> Iterator[Dict[str, Union[str, datetime.datetime]]]:
     group_dict = {
         "group_name": "test group",
         "purpose": "testing",
-        "create_user": famConstants.FAM_PROXY_API_USER,
+        "create_user": testConstants.FAM_PROXY_API_USER,
         "create_date": datetime.datetime.now(),
     }
     yield group_dict

--- a/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
@@ -77,29 +77,30 @@ def dbsession_user_role_assignment(
 
 
 @pytest.fixture(scope="function")
-def dbsession_fam_application(dbsession_fam_app_environment):
+def dbsession_fom_dev_application(dbsession_fam_app_environment):
     db = dbsession_fam_app_environment
-    fam_application = model.FamApplication(
+    fom_dev_application = model.FamApplication(
         **{
             "application_name": "FOM",
             "application_description": "Forest Operations Map",
             "create_user": famConstants.FAM_PROXY_API_USER,
+            "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
     )
-    db.add(fam_application)
+    db.add(fom_dev_application)
     db.commit()
     yield db
 
-    db.delete(fam_application)
+    db.delete(fom_dev_application)
     db.commit()
 
 
 @pytest.fixture(scope="function")
 def dbsession_FOM_submitter_role(  # noqa NOSONAR
-    dbsession_role_types, dbsession_fam_application
+    dbsession_role_types, dbsession_fom_dev_application
 ):
-    db = dbsession_fam_application
-    fam_application: model.FamApplication = (db.query(model.FamApplication).all())[0]
+    db: session.Session = dbsession_fom_dev_application
+    fom_dev_application: model.FamApplication = (db.query(model.FamApplication).all())[0]
 
     # add a role record to db
     fom_submitter_role = model.FamRole(
@@ -107,7 +108,7 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
             "role_name": FOM_SUBMITTER_ROLE_NAME,
             "role_purpose": "Grant a user access to submit to FOM",
             "create_user": famConstants.FAM_PROXY_API_USER,
-            "application_id": fam_application.application_id,
+            "application_id": fom_dev_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
         }
     )
@@ -127,8 +128,8 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
 
 
 @pytest.fixture(scope="function")
-def dbsession_concrete_role(dbsession_role_types, dbsession_fam_application):
-    db = dbsession_fam_application
+def dbsession_concrete_role(dbsession_role_types, dbsession_fom_dev_application):
+    db = dbsession_fom_dev_application
     fam_application: model.FamApplication = (db.query(model.FamApplication).all())[0]
 
     # add a role record to db

--- a/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import session
 LOGGER = logging.getLogger(__name__)
 
 FOM_SUBMITTER_ROLE_NAME = "FOM_Submitter"
-
+FOM_APP_DESC = "Forest Operations Map"
 
 @pytest.fixture(scope="function")
 def user_role_dict() -> Iterator[Dict[str, Union[str, int]]]:
@@ -82,7 +82,7 @@ def dbsession_fom_dev_application(dbsession_fam_app_environment):
     fom_dev_application = model.FamApplication(
         **{
             "application_name": "FOM",
-            "application_description": "Forest Operations Map",
+            "application_description": FOM_APP_DESC,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
@@ -101,7 +101,7 @@ def dbsession_fom_dev_test_applications(dbsession_fam_app_environment):
     fom_dev_application = model.FamApplication(
         **{
             "application_name": "fom_dev",
-            "application_description": "Forest Operations Map",
+            "application_description": FOM_APP_DESC,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
@@ -111,7 +111,7 @@ def dbsession_fom_dev_test_applications(dbsession_fam_app_environment):
     fom_test_application = model.FamApplication(
         **{
             "application_name": "fom_test",
-            "application_description": "Forest Operations Map",
+            "application_description": FOM_APP_DESC,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_TEST
         }
@@ -159,7 +159,7 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
 
 
 @pytest.fixture(scope="function")
-def dbsession_FOM_submitter_role_dev_test(
+def dbsession_fom_submitter_role_dev_test(
     dbsession_role_types, dbsession_fom_dev_test_applications
 ):
     db: session.Session = dbsession_fom_dev_test_applications

--- a/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
@@ -10,8 +10,6 @@ from sqlalchemy.orm import session
 
 LOGGER = logging.getLogger(__name__)
 
-FOM_SUBMITTER_ROLE_NAME = "FOM_Submitter"
-FOM_APP_DESC = "Forest Operations Map"
 
 @pytest.fixture(scope="function")
 def user_role_dict() -> Iterator[Dict[str, Union[str, int]]]:
@@ -82,7 +80,7 @@ def dbsession_fom_dev_application(dbsession_fam_app_environment):
     fom_dev_application = model.FamApplication(
         **{
             "application_name": "FOM",
-            "application_description": FOM_APP_DESC,
+            "application_description": famConstants.FOM_APP_DESC,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
@@ -100,8 +98,8 @@ def dbsession_fom_dev_test_applications(dbsession_fam_app_environment):
     db = dbsession_fam_app_environment
     fom_dev_application = model.FamApplication(
         **{
-            "application_name": "fom_dev",
-            "application_description": FOM_APP_DESC,
+            "application_name": famConstants.FOM_APP_DEV_NAME,
+            "application_description": famConstants.FOM_APP_DESC,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
@@ -110,8 +108,8 @@ def dbsession_fom_dev_test_applications(dbsession_fam_app_environment):
 
     fom_test_application = model.FamApplication(
         **{
-            "application_name": "fom_test",
-            "application_description": FOM_APP_DESC,
+            "application_name": famConstants.FOM_APP_TEST_NAME,
+            "application_description": famConstants.FOM_APP_DESC,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_TEST
         }
@@ -136,8 +134,8 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
     # add a role record to db
     fom_submitter_role = model.FamRole(
         **{
-            "role_name": FOM_SUBMITTER_ROLE_NAME,
-            "role_purpose": "Grant a user access to submit to FOM",
+            "role_name": famConstants.FOM_SUBMITTER_ROLE_NAME,
+            "role_purpose": famConstants.FOM_ROLE_PURPOSE,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "application_id": fom_dev_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
@@ -149,7 +147,7 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
 
     role_db_item = (
         db.query(model.FamRole)
-        .filter(model.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME)
+        .filter(model.FamRole.role_name == famConstants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
 
@@ -171,8 +169,8 @@ def dbsession_fom_submitter_role_dev_test(
     # add role records to db
     fom_dev_submitter_role = model.FamRole(
         **{
-            "role_name": FOM_SUBMITTER_ROLE_NAME,
-            "role_purpose": "Grant a user access to submit to FOM",
+            "role_name": famConstants.FOM_SUBMITTER_ROLE_NAME,
+            "role_purpose": famConstants.FOM_ROLE_PURPOSE,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "application_id": fom_dev_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
@@ -182,8 +180,8 @@ def dbsession_fom_submitter_role_dev_test(
 
     fom_test_submitter_role = model.FamRole(
         **{
-            "role_name": FOM_SUBMITTER_ROLE_NAME,
-            "role_purpose": "Grant a user access to submit to FOM",
+            "role_name": famConstants.FOM_SUBMITTER_ROLE_NAME,
+            "role_purpose": famConstants.FOM_ROLE_PURPOSE,
             "create_user": famConstants.FAM_PROXY_API_USER,
             "application_id": fom_test_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
@@ -195,7 +193,7 @@ def dbsession_fom_submitter_role_dev_test(
     yield db
 
     db.query(model.FamRole)\
-        .filter(model.FamRole.role_name == FOM_SUBMITTER_ROLE_NAME)\
+        .filter(model.FamRole.role_name == famConstants.FOM_SUBMITTER_ROLE_NAME)\
         .delete()
     db.commit()
 

--- a/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
+++ b/server/backend/tests/tests/fixtures/fixtures_crud_user_role_assignment.py
@@ -5,6 +5,7 @@ import api.app.constants as famConstants
 import api.app.models.model as model
 import api.app.schemas as schemas
 import pytest
+import tests.tests.test_constants as testConstants
 from sqlalchemy import text
 from sqlalchemy.orm import session
 
@@ -40,8 +41,8 @@ def dbsession_user_role_assignment(
     fam_user = model.FamUser(
         **{
             "user_type_code": famConstants.UserType.IDIR,
-            "user_name": famConstants.DUMMY_FOREST_CLIENT_NAME,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "user_name": testConstants.DUMMY_FOREST_CLIENT_NAME,
+            "create_user": testConstants.FAM_PROXY_API_USER,
         }
     )
     db.add(fam_user)
@@ -52,7 +53,7 @@ def dbsession_user_role_assignment(
         **{
             "user_id": fam_user.user_id,
             "role_id": fam_role.role_id,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "create_user": testConstants.FAM_PROXY_API_USER,
         }
     )
     db.add(user_role_assignment)
@@ -80,8 +81,8 @@ def dbsession_fom_dev_application(dbsession_fam_app_environment):
     fom_dev_application = model.FamApplication(
         **{
             "application_name": "FOM",
-            "application_description": famConstants.FOM_APP_DESC,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "application_description": testConstants.FOM_APP_DESC,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
     )
@@ -98,9 +99,9 @@ def dbsession_fom_dev_test_applications(dbsession_fam_app_environment):
     db = dbsession_fam_app_environment
     fom_dev_application = model.FamApplication(
         **{
-            "application_name": famConstants.FOM_APP_DEV_NAME,
-            "application_description": famConstants.FOM_APP_DESC,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "application_name": testConstants.FOM_APP_DEV_NAME,
+            "application_description": testConstants.FOM_APP_DESC,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_DEV
         }
     )
@@ -108,9 +109,9 @@ def dbsession_fom_dev_test_applications(dbsession_fam_app_environment):
 
     fom_test_application = model.FamApplication(
         **{
-            "application_name": famConstants.FOM_APP_TEST_NAME,
-            "application_description": famConstants.FOM_APP_DESC,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "application_name": testConstants.FOM_APP_TEST_NAME,
+            "application_description": testConstants.FOM_APP_DESC,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "app_environment": famConstants.AppEnv.APP_ENV_TYPE_TEST
         }
     )
@@ -134,9 +135,9 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
     # add a role record to db
     fom_submitter_role = model.FamRole(
         **{
-            "role_name": famConstants.FOM_SUBMITTER_ROLE_NAME,
-            "role_purpose": famConstants.FOM_ROLE_PURPOSE,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "role_name": testConstants.FOM_SUBMITTER_ROLE_NAME,
+            "role_purpose": testConstants.FOM_ROLE_PURPOSE,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "application_id": fom_dev_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
         }
@@ -147,7 +148,7 @@ def dbsession_FOM_submitter_role(  # noqa NOSONAR
 
     role_db_item = (
         db.query(model.FamRole)
-        .filter(model.FamRole.role_name == famConstants.FOM_SUBMITTER_ROLE_NAME)
+        .filter(model.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME)
         .one_or_none()
     )
 
@@ -169,9 +170,9 @@ def dbsession_fom_submitter_role_dev_test(
     # add role records to db
     fom_dev_submitter_role = model.FamRole(
         **{
-            "role_name": famConstants.FOM_SUBMITTER_ROLE_NAME,
-            "role_purpose": famConstants.FOM_ROLE_PURPOSE,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "role_name": testConstants.FOM_SUBMITTER_ROLE_NAME,
+            "role_purpose": testConstants.FOM_ROLE_PURPOSE,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "application_id": fom_dev_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
         }
@@ -180,9 +181,9 @@ def dbsession_fom_submitter_role_dev_test(
 
     fom_test_submitter_role = model.FamRole(
         **{
-            "role_name": famConstants.FOM_SUBMITTER_ROLE_NAME,
-            "role_purpose": famConstants.FOM_ROLE_PURPOSE,
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "role_name": testConstants.FOM_SUBMITTER_ROLE_NAME,
+            "role_purpose": testConstants.FOM_ROLE_PURPOSE,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "application_id": fom_test_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_ABSTRACT,
         }
@@ -193,7 +194,7 @@ def dbsession_fom_submitter_role_dev_test(
     yield db
 
     db.query(model.FamRole)\
-        .filter(model.FamRole.role_name == famConstants.FOM_SUBMITTER_ROLE_NAME)\
+        .filter(model.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME)\
         .delete()
     db.commit()
 
@@ -209,7 +210,7 @@ def dbsession_concrete_role(dbsession_role_types, dbsession_fom_dev_application)
         **{
             "role_name": role_name,
             "role_purpose": "Concrete role for application",
-            "create_user": famConstants.FAM_PROXY_API_USER,
+            "create_user": testConstants.FAM_PROXY_API_USER,
             "application_id": fam_application.application_id,
             "role_type_code": famConstants.RoleType.ROLE_TYPE_CONCRETE,
         }

--- a/server/backend/tests/tests/router/test_router_userRoleAssignment.py
+++ b/server/backend/tests/tests/router/test_router_userRoleAssignment.py
@@ -102,7 +102,7 @@ def test_create_user_role_assignment_with_concrete_role(
     del request_data["forest_client_number"]
 
     claims = jwt_utils.create_jwt_claims()
-    claims[jwt_validation.JWT_GROUPS_KEY] = "FOM_ACCESS_ADMIN"
+    claims[jwt_validation.JWT_GROUPS_KEY] = ["FOM_ACCESS_ADMIN"]
     token = jwt_utils.create_jwt_token(test_rsa_key, claims)
 
     # Execute POST (role assignment created)
@@ -169,3 +169,120 @@ def test_delete_user_role_assignment(
         model.FamUserRoleXref
     ).all()
     assert len(user_role_assignment_db_items) == 0
+
+
+def test_assign_same_application_roles_for_different_environments(
+    test_client_fixture,
+    dbsession_fam_user_types,
+    dbsession_fom_submitter_role_dev_test,
+    user_role_dict,
+    clean_up_all_user_role_assignment,
+    test_rsa_key
+):
+    db: Session = dbsession_fom_submitter_role_dev_test
+
+    # Verify no assignment initially.
+    user_role_assignment_db_items = db.query(model.FamUserRoleXref).all()
+    assert len(user_role_assignment_db_items) == 0
+
+    # Verify setup correctly
+    fom_dev_application: model.FamApplication = (
+        db.query(model.FamApplication)
+        .filter(
+            model.FamApplication.app_environment == constants.AppEnv.APP_ENV_TYPE_DEV)
+        .one()
+    )
+    fom_test_application: model.FamApplication = (
+        db.query(model.FamApplication)
+        .filter(
+            model.FamApplication.app_environment == constants.AppEnv.APP_ENV_TYPE_TEST)
+        .one()
+    )
+    assert fom_dev_application.application_name == constants.FOM_APP_DEV_NAME
+    assert fom_test_application.application_name == constants.FOM_APP_TEST_NAME
+
+    fom_dev_submitter_role: model.FamRole = (
+        db.query(model.FamRole)
+        .filter(
+            model.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
+            model.FamRole.application_id == fom_dev_application.application_id)
+        .one()
+    )
+    fom_test_submitter_role: model.FamRole = (
+        db.query(model.FamRole)
+        .filter(
+            model.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
+            model.FamRole.application_id == fom_test_application.application_id)
+        .one()
+    )
+
+    # Prepare dev, test data
+    request_dev_data = copy.deepcopy(user_role_dict)
+    request_dev_data["role_id"] = fom_dev_submitter_role.role_id
+    request_test_data = copy.deepcopy(user_role_dict)
+    request_test_data["role_id"] = fom_test_submitter_role.role_id
+
+    claims = jwt_utils.create_jwt_claims()
+    claims[jwt_validation.JWT_GROUPS_KEY] = ["FOM_DEV_ACCESS_ADMIN", "FOM_TEST_ACCESS_ADMIN"]
+    token = jwt_utils.create_jwt_token(test_rsa_key, claims)
+
+    # Execute POST (fom_dev)
+    response_dev = test_client_fixture.post(
+        f"{endPoint}",
+        json=request_dev_data,
+        headers=jwt_utils.headers(token)
+    )
+    # Verify dev request status
+    assert response_dev.status_code == 200
+    assert response_dev.json() is not None
+
+    # Execute POST (fom_test)
+    response_test = test_client_fixture.post(
+        f"{endPoint}",
+        json=request_test_data,
+        headers=jwt_utils.headers(token)
+    )
+    # Verify test request status
+    assert response_test.status_code == 200
+    assert response_test.json() is not None
+
+    assignment_user_role_id_dev = response_dev.json()["user_role_xref_id"]
+    assignment_user_role_id_test = response_test.json()["user_role_xref_id"]
+    assert assignment_user_role_id_dev != assignment_user_role_id_test
+
+    assignment_role_id_dev = response_dev.json()["role_id"]
+    assignment_role_id_test = response_test.json()["role_id"]
+    assert assignment_role_id_dev != assignment_role_id_test  # Verify assignment id not the same.
+
+    assignment_role_dev_db_item: model.FamRole = (
+        db.query(model.FamRole)
+        .filter(model.FamRole.role_id == assignment_role_id_dev)
+        .one()
+    )
+    assignment_role_test_db_item: model.FamRole = (
+        db.query(model.FamRole)
+        .filter(model.FamRole.role_id == assignment_role_id_test)
+        .one()
+    )
+    # Verify role with associated parent role and application.
+    assert assignment_role_id_dev != fom_dev_submitter_role.role_id
+    assert assignment_role_id_test != fom_test_submitter_role.role_id
+    assert assignment_role_dev_db_item.parent_role_id == fom_dev_submitter_role.role_id
+    assert assignment_role_test_db_item.parent_role_id == fom_test_submitter_role.role_id
+    assert assignment_role_dev_db_item.application.application_name ==\
+        fom_dev_application.application_name
+    assert assignment_role_test_db_item.application.application_name ==\
+        fom_test_application.application_name
+
+    # Execute Delete dev_role assignment
+    test_client_fixture.delete(
+        f"{endPoint}/{assignment_user_role_id_dev}",
+        headers=jwt_utils.headers(token)
+    )
+
+    # Verify correctly delet user/role assignment
+    user_role_assignment_db_items: model.FamUserRoleXref = db.query(
+        model.FamUserRoleXref
+    ).all()
+    assert len(user_role_assignment_db_items) == 1
+    assert user_role_assignment_db_items[0].role_id != assignment_role_id_dev

--- a/server/backend/tests/tests/router/test_router_userRoleAssignment.py
+++ b/server/backend/tests/tests/router/test_router_userRoleAssignment.py
@@ -1,12 +1,13 @@
 import copy
 import logging
 
-import api.app.models.model as model
 import api.app.constants as constants
+import api.app.jwt_validation as jwt_validation
+import api.app.models.model as model
+import tests.jwt_utils as jwt_utils
+import tests.tests.test_constants as testConstants
 from api.app.main import apiPrefix
 from sqlmodel import Session
-import tests.jwt_utils as jwt_utils
-import api.app.jwt_validation as jwt_validation
 
 LOGGER = logging.getLogger(__name__)
 endPoint = f"{apiPrefix}/user_role_assignment"
@@ -198,20 +199,20 @@ def test_assign_same_application_roles_for_different_environments(
             model.FamApplication.app_environment == constants.AppEnv.APP_ENV_TYPE_TEST)
         .one()
     )
-    assert fom_dev_application.application_name == constants.FOM_APP_DEV_NAME
-    assert fom_test_application.application_name == constants.FOM_APP_TEST_NAME
+    assert fom_dev_application.application_name == testConstants.FOM_APP_DEV_NAME
+    assert fom_test_application.application_name == testConstants.FOM_APP_TEST_NAME
 
     fom_dev_submitter_role: model.FamRole = (
         db.query(model.FamRole)
         .filter(
-            model.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
+            model.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME,
             model.FamRole.application_id == fom_dev_application.application_id)
         .one()
     )
     fom_test_submitter_role: model.FamRole = (
         db.query(model.FamRole)
         .filter(
-            model.FamRole.role_name == constants.FOM_SUBMITTER_ROLE_NAME,
+            model.FamRole.role_name == testConstants.FOM_SUBMITTER_ROLE_NAME,
             model.FamRole.application_id == fom_test_application.application_id)
         .one()
     )

--- a/server/backend/tests/tests/test_constants.py
+++ b/server/backend/tests/tests/test_constants.py
@@ -1,0 +1,12 @@
+
+FAM_PROXY_API_USER = "fam_proxy_api"
+
+COGNITO_USERNAME_KEY = "username"
+
+FOM_SUBMITTER_ROLE_NAME = "FOM_Submitter"
+FOM_APP_DESC = "Forest Operations Map"
+FOM_ROLE_PURPOSE = "Grant a user access to submit to FOM"
+FOM_APP_DEV_NAME = "fom_dev"
+FOM_APP_TEST_NAME = "fom_test"
+
+DUMMY_FOREST_CLIENT_NAME = "DUMMY_FOREST_CLIENT_NAME"


### PR DESCRIPTION
This PR is to fix bug described in #516.
* The bug is identified as a wrong query result on crud_role.get_role_by_role_name(), which is missing one more filtering parameter (application_id) as now FAM role is environment(application) specific (dev/test/prod).
* Previous FAM fam_role table had initial unique constraint as (role_name) only. Then some time ago, this constraint is updated to (role_name, application_id) after FAM has multiple application environments(such as fom_dev/fom_test/fom_prod) for each FAM environment and the function was missed to upgrade along that change.