### PR TITLE
fix: #519 fam cognito logout for fom TEST not working

### DIFF
--- a/infrastructure/server/oidc_clients_fom.tf
+++ b/infrastructure/server/oidc_clients_fom.tf
@@ -8,7 +8,7 @@ resource "aws_cognito_user_pool_client" "dev_fom_oidc_client" {
     "http://localhost:4200/admin/search"
   ]
   logout_urls                                   = [
-    "${var.frontend_logout_chain_url}http://localhost:4200/admin/not-authorized?loggedout=true"
+    "${var.cognito_app_client_logout_chain_url.dev}http://localhost:4200/admin/not-authorized?loggedout=true"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -44,7 +44,7 @@ resource "aws_cognito_user_pool_client" "test_fom_oidc_client" {
     "http://localhost:4200/admin/search"
   ]
   logout_urls                                   = [
-    "${var.frontend_logout_chain_url}https://fom-test.nrs.gov.bc.ca/admin/not-authorized?loggedout=true"
+    "${var.cognito_app_client_logout_chain_url.test}https://fom-test.nrs.gov.bc.ca/admin/not-authorized?loggedout=true"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -78,7 +78,7 @@ resource "aws_cognito_user_pool_client" "prod_fom_oidc_client" {
     "https://fom.nrs.gov.bc.ca/admin/search",
   ]
   logout_urls                                   = [
-    "${var.frontend_logout_chain_url}https://fom.nrs.gov.bc.ca/admin/not-authorized?loggedout=true"
+    "${var.cognito_app_client_logout_chain_url.prod}https://fom.nrs.gov.bc.ca/admin/not-authorized?loggedout=true"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"

--- a/infrastructure/server/oidc_clients_spar.tf
+++ b/infrastructure/server/oidc_clients_spar.tf
@@ -9,8 +9,8 @@ resource "aws_cognito_user_pool_client" "dev_spar_oidc_client" {
     "http://localhost:3000/silent-check-sso"
   ]
   logout_urls                                   = [
-    "${var.frontend_logout_chain_url}https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/",
-    "${var.frontend_logout_chain_url}http://localhost:3000/"
+    "${var.cognito_app_client_logout_chain_url.dev}https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/",
+    "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000/"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -45,7 +45,7 @@ resource "aws_cognito_user_pool_client" "test_spar_oidc_client" {
     "https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/dashboard"
   ]
   logout_urls                                   = [
-    "${var.frontend_logout_chain_url}https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/"
+    "${var.cognito_app_client_logout_chain_url.test}https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -79,7 +79,7 @@ resource "aws_cognito_user_pool_client" "prod_spar_oidc_client" {
     "https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/dashboard"
   ]
   logout_urls                                   = [
-    "${var.frontend_logout_chain_url}https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/"
+    "${var.cognito_app_client_logout_chain_url.prod}https://nr-spar-webapp-test-frontend.apps.silver.devops.gov.bc.ca/"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"

--- a/infrastructure/server/outputs.tf
+++ b/infrastructure/server/outputs.tf
@@ -26,8 +26,10 @@ output "fam_cognito_domain" {
 }
 
 output "frontend_logout_chain_url" {
-  description = "Url of Siteminder and Keycloak logout chain for frontend"
-  value = var.frontend_logout_chain_url
+  description = "Url of Siteminder and Keycloak logout chain for FAM frontend"
+  value = var.target_env == "prod" ? var.cognito_app_client_logout_chain_url.prod : (
+          var.target_env == "test" ? var.cognito_app_client_logout_chain_url.test :
+          var.cognito_app_client_logout_chain_url.dev)
 }
 
 output "front_end_redirect_base_url" {

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -122,7 +122,15 @@ variable "db_cluster_snapshot_identifier" {
   }
 }
 
-# Variables for front-end config
+# Variables for Cognito Client config
+
+variable "cognito_app_client_logout_chain_url" {
+  description = "Url of Siteminder and Keycloak logout chain for Cognito client on all environments(dev, test, prod)"
+  type = map
+}
+
+
+# Variables for FAM front-end config
 
 variable "frontend_logout_chain_url" {
   description = "Url of Siteminder and Keycloak logout chain for frontend"

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -135,6 +135,7 @@ variable "cognito_app_client_logout_chain_url" {
 variable "frontend_logout_chain_url" {
   description = "Url of Siteminder and Keycloak logout chain for frontend"
   type = string
+  default = "${var.cognito_app_client_logout_chain_url.dev}"
 }
 
 variable "front_end_redirect_path" {

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -135,7 +135,7 @@ variable "cognito_app_client_logout_chain_url" {
 variable "frontend_logout_chain_url" {
   description = "Url of Siteminder and Keycloak logout chain for frontend"
   type = string
-  default = "${var.cognito_app_client_logout_chain_url.dev}"
+  default = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
 }
 
 variable "front_end_redirect_path" {

--- a/terraform/common_vars.hcl
+++ b/terraform/common_vars.hcl
@@ -1,0 +1,7 @@
+
+# Cognito App Clients Common Vars.
+locals {
+  idp_logout_chain_dev_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+  idp_logout_chain_test_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+  idp_logout_chain_prod_url = "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+}

--- a/terraform/common_vars.hcl
+++ b/terraform/common_vars.hcl
@@ -1,6 +1,6 @@
 
 # Cognito App Clients Common Vars.
-locals {
+inputs = {
   idp_logout_chain_dev_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
   idp_logout_chain_test_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
   idp_logout_chain_prod_url = "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="

--- a/terraform/dev/terragrunt.hcl
+++ b/terraform/dev/terragrunt.hcl
@@ -25,9 +25,9 @@ generate "dev_tfvars" {
   subnet_app_a = "App_Dev_aza_net"
   subnet_app_b = "App_Dev_azb_net"
   cognito_app_client_logout_chain_url = {
-    dev = "${local.common_vars.idp_logout_chain_dev_url}"
-    test = "${local.common_vars.idp_logout_chain_test_url}"
-    prod = "${local.common_vars.idp_logout_chain_prod_url}"
+    dev = "${local.common_vars.inputs.idp_logout_chain_dev_url}"
+    test = "${local.common_vars.inputs.idp_logout_chain_test_url}"
+    prod = "${local.common_vars.inputs.idp_logout_chain_prod_url}"
   }
   front_end_redirect_path = "https://fam-dev.nrs.gov.bc.ca"
   local_frontend_redirect_path = "http://localhost:5173"
@@ -38,8 +38,8 @@ generate "dev_tfvars" {
     "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/"
   ]
   fam_logout_urls = [
-    "${local.common_vars.idp_logout_chain_dev_url}https://fam-dev.nrs.gov.bc.ca",
-    "${local.common_vars.idp_logout_chain_dev_url}http://localhost:5173"
+    "${local.common_vars.inputs.idp_logout_chain_dev_url}https://fam-dev.nrs.gov.bc.ca",
+    "${local.common_vars.inputs.idp_logout_chain_dev_url}http://localhost:5173"
   ]
   fam_console_idp_name = "DEV-IDIR"
 EOF

--- a/terraform/dev/terragrunt.hcl
+++ b/terraform/dev/terragrunt.hcl
@@ -2,6 +2,10 @@ include {
   path = find_in_parent_folders()
 }
 
+locals {
+  common_vars = read_terragrunt_config(find_in_parent_folders("common_vars.hcl"))
+}
+
 generate "dev_tfvars" {
   path              = "dev.auto.tfvars"
   if_exists         = "overwrite"
@@ -20,7 +24,11 @@ generate "dev_tfvars" {
   aws_security_group_app = "App_sg"
   subnet_app_a = "App_Dev_aza_net"
   subnet_app_b = "App_Dev_azb_net"
-  frontend_logout_chain_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+  cognito_app_client_logout_chain_url = {
+    dev = "${local.common_vars.idp_logout_chain_dev_url}"
+    test = "${local.common_vars.idp_logout_chain_test_url}"
+    prod = "${local.common_vars.idp_logout_chain_prod_url}"
+  }
   front_end_redirect_path = "https://fam-dev.nrs.gov.bc.ca"
   local_frontend_redirect_path = "http://localhost:5173"
   fam_callback_urls = [
@@ -30,8 +38,8 @@ generate "dev_tfvars" {
     "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/"
   ]
   fam_logout_urls = [
-    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=https://fam-dev.nrs.gov.bc.ca",
-    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=http://localhost:5173"
+    "${local.common_vars.idp_logout_chain_dev_url}https://fam-dev.nrs.gov.bc.ca",
+    "${local.common_vars.idp_logout_chain_dev_url}http://localhost:5173"
   ]
   fam_console_idp_name = "DEV-IDIR"
 EOF

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -2,6 +2,10 @@ include {
   path = find_in_parent_folders()
 }
 
+locals {
+  common_vars = read_terragrunt_config(find_in_parent_folders("common_vars.hcl"))
+}
+
 generate "prod_tfvars" {
   path              = "prod.auto.tfvars"
   if_exists         = "overwrite"
@@ -20,15 +24,19 @@ generate "prod_tfvars" {
   aws_security_group_app = "App_sg"
   subnet_app_a = "App_Prod_aza_net"
   subnet_app_b = "App_Prod_azb_net"
-  frontend_logout_chain_url = "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
   front_end_redirect_path = "https://fam.nrs.gov.bc.ca"
   local_frontend_redirect_path = "http://localhost:5173"
+  cognito_app_client_logout_chain_url = {
+    dev = "${local.common_vars.idp_logout_chain_dev_url}"
+    test = "${local.common_vars.idp_logout_chain_test_url}"
+    prod = "${local.common_vars.idp_logout_chain_prod_url}"
+  }
   fam_callback_urls = [
     "https://fam.nrs.gov.bc.ca/authCallback",
     "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/"
   ]
   fam_logout_urls = [
-    "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=https://fam.nrs.gov.bc.ca",
+    "${local.common_vars.idp_logout_chain_prod_url}https://fam.nrs.gov.bc.ca",
   ]
   fam_console_idp_name = "PROD-IDIR"
 EOF

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -27,16 +27,16 @@ generate "prod_tfvars" {
   front_end_redirect_path = "https://fam.nrs.gov.bc.ca"
   local_frontend_redirect_path = "http://localhost:5173"
   cognito_app_client_logout_chain_url = {
-    dev = "${local.common_vars.idp_logout_chain_dev_url}"
-    test = "${local.common_vars.idp_logout_chain_test_url}"
-    prod = "${local.common_vars.idp_logout_chain_prod_url}"
+    dev = "${local.common_vars.inputs.idp_logout_chain_dev_url}"
+    test = "${local.common_vars.inputs.idp_logout_chain_test_url}"
+    prod = "${local.common_vars.inputs.idp_logout_chain_prod_url}"
   }
   fam_callback_urls = [
     "https://fam.nrs.gov.bc.ca/authCallback",
     "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/"
   ]
   fam_logout_urls = [
-    "${local.common_vars.idp_logout_chain_prod_url}https://fam.nrs.gov.bc.ca",
+    "${local.common_vars.inputs.idp_logout_chain_prod_url}https://fam.nrs.gov.bc.ca",
   ]
   fam_console_idp_name = "PROD-IDIR"
 EOF

--- a/terraform/test/terragrunt.hcl
+++ b/terraform/test/terragrunt.hcl
@@ -2,6 +2,10 @@ include {
   path = find_in_parent_folders()
 }
 
+locals {
+  common_vars = read_terragrunt_config(find_in_parent_folders("common_vars.hcl"))
+}
+
 generate "test_tfvars" {
   path              = "test.auto.tfvars"
   if_exists         = "overwrite"
@@ -16,7 +20,11 @@ generate "test_tfvars" {
   aws_security_group_app = "App_sg"
   subnet_app_a = "App_Test_aza_net"
   subnet_app_b = "App_Test_azb_net"
-  frontend_logout_chain_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+  cognito_app_client_logout_chain_url = {
+    dev = "${local.common_vars.idp_logout_chain_dev_url}"
+    test = "${local.common_vars.idp_logout_chain_test_url}"
+    prod = "${local.common_vars.idp_logout_chain_prod_url}"
+  }
   front_end_redirect_path = "https://fam-tst.nrs.gov.bc.ca"
   fam_callback_urls = [
     "https://fam-tst.nrs.gov.bc.ca/authCallback",
@@ -25,8 +33,8 @@ generate "test_tfvars" {
     "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/"
   ]
   fam_logout_urls = [
-    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=https://fam-tst.nrs.gov.bc.ca",
-    "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=http://localhost:5173"
+    "${local.common_vars.idp_logout_chain_test_url}https://fam-tst.nrs.gov.bc.ca",
+    "${local.common_vars.idp_logout_chain_test_url}http://localhost:5173"
   ]
   fam_console_idp_name = "TEST-IDIR"
 EOF

--- a/terraform/test/terragrunt.hcl
+++ b/terraform/test/terragrunt.hcl
@@ -21,9 +21,9 @@ generate "test_tfvars" {
   subnet_app_a = "App_Test_aza_net"
   subnet_app_b = "App_Test_azb_net"
   cognito_app_client_logout_chain_url = {
-    dev = "${local.common_vars.idp_logout_chain_dev_url}"
-    test = "${local.common_vars.idp_logout_chain_test_url}"
-    prod = "${local.common_vars.idp_logout_chain_prod_url}"
+    dev = "${local.common_vars.inputs.idp_logout_chain_dev_url}"
+    test = "${local.common_vars.inputs.idp_logout_chain_test_url}"
+    prod = "${local.common_vars.inputs.idp_logout_chain_prod_url}"
   }
   front_end_redirect_path = "https://fam-tst.nrs.gov.bc.ca"
   fam_callback_urls = [
@@ -33,8 +33,8 @@ generate "test_tfvars" {
     "https://oidcdebuggersecure-3d5c3f-dev.apps.silver.devops.gov.bc.ca/"
   ]
   fam_logout_urls = [
-    "${local.common_vars.idp_logout_chain_test_url}https://fam-tst.nrs.gov.bc.ca",
-    "${local.common_vars.idp_logout_chain_test_url}http://localhost:5173"
+    "${local.common_vars.inputs.idp_logout_chain_test_url}https://fam-tst.nrs.gov.bc.ca",
+    "${local.common_vars.inputs.idp_logout_chain_test_url}http://localhost:5173"
   ]
   fam_console_idp_name = "TEST-IDIR"
 EOF


### PR DESCRIPTION
The PR fixes logout_chain_url not matching with Cognito app clients environments ([app]_dev, [app]_test, [app]_prod)
* Migrate common logout chain urls (Cognito app client env specific) to common_vars.hcl.
* Setup terragrun "cognito_app_client_logout_chain_url" var as a map so oidc app client can reference to it with environments(dev, test, prod)
* Use "local.common_vars.inputs.idp_logout_chain_dev_url" to make values DRY on each environment's setting.
* Make sure oidc_client_fom.tf/oidc_client_spar.tf use environment specific value for dev/test/prod