### PR TITLE
ci: Pinned aurora_postgresql_v2 version to prevent deploy issues

### DIFF
--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -47,6 +47,7 @@ data "aws_rds_engine_version" "postgresql" {
 
 module "aurora_postgresql_v2" {
   source = "terraform-aws-modules/rds-aurora/aws"
+  version = "7.7.1"
 
   name              = var.famdb_cluster_name
   engine            = data.aws_rds_engine_version.postgresql.engine


### PR DESCRIPTION
The code for this Terraform module was upgraded last week with a new major version which has breaking changes. By pinning the version to 7.7.1 the deployment still works.