### PR TITLE
chore: Remove unnecessary "@types/node": "^18.0.0" from frontend.

### DIFF
--- a/client-code-gen/gen/package-lock.json
+++ b/client-code-gen/gen/package-lock.json
@@ -12,15 +12,8 @@
         "axios": "^0.26.1"
       },
       "devDependencies": {
-        "@types/node": "^18.0.0",
         "typescript": "^4.0"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "18.16.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.9.tgz",
-      "integrity": "sha512-IeB32oIV4oGArLrd7znD2rkHQ6EDCM+2Sr76dJnrHwv9OHBTTM6nuDLK9bmikXzPa0ZlWMWtRGo/Uw4mrzQedA==",
-      "dev": true
     },
     "node_modules/axios": {
       "version": "0.26.1",
@@ -64,12 +57,6 @@
     }
   },
   "dependencies": {
-    "@types/node": {
-      "version": "18.16.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.9.tgz",
-      "integrity": "sha512-IeB32oIV4oGArLrd7znD2rkHQ6EDCM+2Sr76dJnrHwv9OHBTTM6nuDLK9bmikXzPa0ZlWMWtRGo/Uw4mrzQedA==",
-      "dev": true
-    },
     "axios": {
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",

--- a/client-code-gen/gen/package.json
+++ b/client-code-gen/gen/package.json
@@ -27,7 +27,6 @@
     "axios": "^0.26.1"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
     "typescript": "^4.0"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,6 @@
             },
             "devDependencies": {
                 "@types/bootstrap": "^5.2.5",
-                "@types/node": "^18.0.0",
                 "@vitejs/plugin-vue": "^4.0.0",
                 "@vitest/coverage-c8": "^0.24.5",
                 "@vue/test-utils": "^2.2.1",
@@ -53,7 +52,6 @@
                 "axios": "^0.26.1"
             },
             "devDependencies": {
-                "@types/node": "^18.0.0",
                 "typescript": "^4.0"
             }
         },
@@ -32082,7 +32080,6 @@
         "fam-api": {
             "version": "file:../client-code-gen/gen",
             "requires": {
-                "@types/node": "^18.0.0",
                 "axios": "^0.26.1",
                 "typescript": "^4.0"
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
     "devDependencies": {
         "@types/bootstrap": "^5.2.5",
         "@vitejs/plugin-vue": "^4.0.0",
-        "@types/node": "^18.0.0",
         "@vitest/coverage-c8": "^0.24.5",
         "@vue/test-utils": "^2.2.1",
         "@vue/tsconfig": "^0.1.3",


### PR DESCRIPTION
Not directly using @types/node, so remove it.
If we do a check with: "npm list @types/node", many other libraries in package.json have "@types/node@18.16.16" dependency already.