### PR TITLE
ci: adjust sonar for auth

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -38,74 +38,74 @@ jobs:
           projectBaseDir: server/auth_function
           args: >
             -Dsonar.exclusions=config.py
-            -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.projectKey=nr-forests-access-management_auth
-            -Dsonar.python.coverage.reportPaths=*coverage*.xml
+            -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.python.version=3.8
+            -Dsonar.source=.
             -Dsonar.tests=test
 
-  ci-backend:
-    runs-on: ubuntu-latest
-    env:
-      environment: dev
-      organization: bcgov
-      POSTGRES_USER: fam_proxy_api
-      POSTGRES_PASSWORD: test
-      POSTGRES_HOST: localhost
-      POSTGRES_DB: fam
-      POSTGRES_PORT: 5432
-      USE_POSTGRES: false
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Deep fetch is required for SonarCloud
-          fetch-depth: 0
+  # ci-backend:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     environment: dev
+  #     organization: bcgov
+  #     POSTGRES_USER: fam_proxy_api
+  #     POSTGRES_PASSWORD: test
+  #     POSTGRES_HOST: localhost
+  #     POSTGRES_DB: fam
+  #     POSTGRES_PORT: 5432
+  #     USE_POSTGRES: false
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         # Deep fetch is required for SonarCloud
+  #         fetch-depth: 0
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: 3.8
 
-      - name: Tests and coverage
-        env:
-          FC_API_TOKEN: ${{ secrets.FOREST_CLIENT_API_API_KEY }}
-        run: |
-          cd server/backend
-          pip install -r requirements.txt -r requirements-dev.txt
-          pip install pytest-cov
-          pytest --cov=. --cov-branch --cov-report=xml \
-            -v --md=report.md --emoji
+  #     - name: Tests and coverage
+  #       env:
+  #         FC_API_TOKEN: ${{ secrets.FOREST_CLIENT_API_API_KEY }}
+  #       run: |
+  #         cd server/backend
+  #         pip install -r requirements.txt -r requirements-dev.txt
+  #         pip install pytest-cov
+  #         pytest --cov=. --cov-branch --cov-report=xml \
+  #           -v --md=report.md --emoji
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
-        with:
-          projectBaseDir: server/backend
-          args: >
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.projectKey=nr-forests-access-management_backend
-            -Dsonar.python.coverage.reportPaths=*coverage*.xml
-            -Dsonar.python.version=3.8
-            -Dsonar.sources=api
-            -Dsonar.tests=testspg
+  #     - name: SonarCloud Scan
+  #       uses: SonarSource/sonarcloud-github-action@master
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+  #       with:
+  #         projectBaseDir: server/backend
+  #         args: >
+  #           -Dsonar.host.url=https://sonarcloud.io
+  #           -Dsonar.organization=bcgov-sonarcloud
+  #           -Dsonar.projectKey=nr-forests-access-management_backend
+  #           -Dsonar.python.coverage.reportPaths=*coverage*.xml
+  #           -Dsonar.python.version=3.8
+  #           -Dsonar.sources=api
+  #           -Dsonar.tests=testspg
 
-  ci-frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: bcgov-nr/action-test-and-analyse@v0.0.1
-        with:
-          commands: |
-            npm run install-frontend
-            npm run test-coverage
-          dir: frontend
-          node_version: "18"
-          sonar_args: >
-            -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.project.monorepo.enabled=true
-            -Dsonar.projectKey=nr-forests-access-management_frontend
-            -Dsonar.sources=src
-          sonar_project_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+  # ci-frontend:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: bcgov-nr/action-test-and-analyse@v0.0.1
+  #       with:
+  #         commands: |
+  #           npm run install-frontend
+  #           npm run test-coverage
+  #         dir: frontend
+  #         node_version: "18"
+  #         sonar_args: >
+  #           -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
+  #           -Dsonar.organization=bcgov-sonarcloud
+  #           -Dsonar.project.monorepo.enabled=true
+  #           -Dsonar.projectKey=nr-forests-access-management_frontend
+  #           -Dsonar.sources=src
+  #         sonar_project_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,12 +37,12 @@ jobs:
         with:
           projectBaseDir: server/auth_function
           args: >
-            -Dsonar.exclusions=config.py
+            -Dsonar.exclusions=**/test/**/*,config.py
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.projectKey=nr-forests-access-management_auth
-            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.coverage.reportPaths=*coverage*.xml
             -Dsonar.python.version=3.8
-            -Dsonar.source=.
+            -Dsonar.sources=.
             -Dsonar.tests=test
 
   ci-backend:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -45,67 +45,67 @@ jobs:
             -Dsonar.source=.
             -Dsonar.tests=test
 
-  # ci-backend:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     environment: dev
-  #     organization: bcgov
-  #     POSTGRES_USER: fam_proxy_api
-  #     POSTGRES_PASSWORD: test
-  #     POSTGRES_HOST: localhost
-  #     POSTGRES_DB: fam
-  #     POSTGRES_PORT: 5432
-  #     USE_POSTGRES: false
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         # Deep fetch is required for SonarCloud
-  #         fetch-depth: 0
+  ci-backend:
+    runs-on: ubuntu-latest
+    env:
+      environment: dev
+      organization: bcgov
+      POSTGRES_USER: fam_proxy_api
+      POSTGRES_PASSWORD: test
+      POSTGRES_HOST: localhost
+      POSTGRES_DB: fam
+      POSTGRES_PORT: 5432
+      USE_POSTGRES: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Deep fetch is required for SonarCloud
+          fetch-depth: 0
 
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: 3.8
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
-  #     - name: Tests and coverage
-  #       env:
-  #         FC_API_TOKEN: ${{ secrets.FOREST_CLIENT_API_API_KEY }}
-  #       run: |
-  #         cd server/backend
-  #         pip install -r requirements.txt -r requirements-dev.txt
-  #         pip install pytest-cov
-  #         pytest --cov=. --cov-branch --cov-report=xml \
-  #           -v --md=report.md --emoji
+      - name: Tests and coverage
+        env:
+          FC_API_TOKEN: ${{ secrets.FOREST_CLIENT_API_API_KEY }}
+        run: |
+          cd server/backend
+          pip install -r requirements.txt -r requirements-dev.txt
+          pip install pytest-cov
+          pytest --cov=. --cov-branch --cov-report=xml \
+            -v --md=report.md --emoji
 
-  #     - name: SonarCloud Scan
-  #       uses: SonarSource/sonarcloud-github-action@master
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
-  #       with:
-  #         projectBaseDir: server/backend
-  #         args: >
-  #           -Dsonar.host.url=https://sonarcloud.io
-  #           -Dsonar.organization=bcgov-sonarcloud
-  #           -Dsonar.projectKey=nr-forests-access-management_backend
-  #           -Dsonar.python.coverage.reportPaths=*coverage*.xml
-  #           -Dsonar.python.version=3.8
-  #           -Dsonar.sources=api
-  #           -Dsonar.tests=testspg
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+        with:
+          projectBaseDir: server/backend
+          args: >
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.projectKey=nr-forests-access-management_backend
+            -Dsonar.python.coverage.reportPaths=*coverage*.xml
+            -Dsonar.python.version=3.8
+            -Dsonar.sources=api
+            -Dsonar.tests=testspg
 
-  # ci-frontend:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: bcgov-nr/action-test-and-analyse@v0.0.1
-  #       with:
-  #         commands: |
-  #           npm run install-frontend
-  #           npm run test-coverage
-  #         dir: frontend
-  #         node_version: "18"
-  #         sonar_args: >
-  #           -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
-  #           -Dsonar.organization=bcgov-sonarcloud
-  #           -Dsonar.project.monorepo.enabled=true
-  #           -Dsonar.projectKey=nr-forests-access-management_frontend
-  #           -Dsonar.sources=src
-  #         sonar_project_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+  ci-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcgov-nr/action-test-and-analyse@v0.0.1
+        with:
+          commands: |
+            npm run install-frontend
+            npm run test-coverage
+          dir: frontend
+          node_version: "18"
+          sonar_args: >
+            -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.project.monorepo.enabled=true
+            -Dsonar.projectKey=nr-forests-access-management_frontend
+            -Dsonar.sources=src
+          sonar_project_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}

--- a/server/auth_function/.coveragerc
+++ b/server/auth_function/.coveragerc
@@ -4,4 +4,3 @@ relative_files = True
 
 [report]
 omit = test/*
-relative_files = True

--- a/server/auth_function/lambda_function.py
+++ b/server/auth_function/lambda_function.py
@@ -164,5 +164,3 @@ def handle_event(db_connection, event) -> event_type.Event:
         }
     }
     return event
-
-# Test/junk commit

--- a/server/auth_function/lambda_function.py
+++ b/server/auth_function/lambda_function.py
@@ -164,3 +164,5 @@ def handle_event(db_connection, event) -> event_type.Event:
         }
     }
     return event
+
+# Test/junk commit

--- a/server/backend/.coveragerc
+++ b/server/backend/.coveragerc
@@ -4,4 +4,3 @@ relative_files = True
 
 [report]
 omit = test/*
-relative_files = True


### PR DESCRIPTION
Sonar Clould isn't generating coverage for auth. This is confusing, because coverage appears to be picked up.

From Sonar run:
```
INFO: Python test coverage
INFO: Parsing report '/github/workspace/server/auth_function/coverage.xml'
```

Small adjustment made, since an error was coming from relative_files in .coveragerc in the [report] section.
```
.venv/lib/python3.11/site-packages/coverage/config.py:324: CoverageWarning: Unrecognized option '[report] relative_files=' in config file .coveragerc
    warn(
...
```

Update: Working!  Combination of .coverragerc and sonar params.