### PR TITLE
fix: #759 Show Next button in the grant access page, but disabled it until meet requirement.

### DIFF
--- a/frontend/src/assets/styles/layout.scss
+++ b/frontend/src/assets/styles/layout.scss
@@ -11,7 +11,7 @@ body {
     top: $header-height;
     left: 16rem;
     right: 0;
-    bottom: 0;
+    bottom: 1rem;
     overflow: auto;
     padding: 2.62rem 1.875rem 0;
 }

--- a/frontend/src/components/grantaccess/GrantAccess.vue
+++ b/frontend/src/components/grantaccess/GrantAccess.vue
@@ -427,16 +427,17 @@ function toSummary() {
                             ></ForestClientCard>
                         </div>
                     </div>
-                    <div
-                        class="row gy-3 my-0"
-                        v-if="meta.valid && areVerificationsPassed()"
-                    >
+                    <div class="row gy-1 my-0">
                         <div class="col-auto px-0">
                             <Button
                                 type="button"
                                 id="grantAccessSubmit"
                                 class="mb-3 button p-button"
                                 label="Next"
+                                :disabled="!(
+                                    meta.valid &&
+                                    areVerificationsPassed()
+                                )"
                                 @click="toSummary()"
                             ></Button>
                             <Button


### PR DESCRIPTION
- Don't hide next button on grant access page, just disable it for form validation.
- Minor adjustment for spacing at the bottom.