### PR TITLE
ci: update and triggers for frontend tests

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -99,7 +99,7 @@ jobs:
   ci-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: bcgov-nr/action-test-and-analyse@v0.0.2
+      - uses: bcgov-nr/action-test-and-analyse@v1.0.0
         with:
           commands: |
             npm run install-frontend
@@ -113,5 +113,6 @@ jobs:
             -Dsonar.projectKey=nr-forests-access-management_frontend
             -Dsonar.sources=src
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-          sonar_project_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+          sonar_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+          triggers: ("frontend" "terraform-frontend/")
 

--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,5 @@ terraform/tools/output.txt
 # Sonar cloud
 **/.scannerwork/**/*
 
-
+# VSCode
+.vscode/


### PR DESCRIPTION
Update bcgov-nr/action-test-and-analyse to v1.0.0.  This adds triggers so tests can be run only if certain folders are changed.  JS/TS only for now.