### PR TITLE
fix: #739 fix dialog icon to always display at top right

### DIFF
--- a/frontend/src/components/common/ToastMessage.vue
+++ b/frontend/src/components/common/ToastMessage.vue
@@ -58,7 +58,7 @@ const onError = (error: any, info: string) => {
             );
         } else if (status == 409) {
             useNotificationMessage.isNotificationVisible = false;
-            useErrorDialog.dialogTitle = axiosResponse.statusText;
+            useErrorDialog.dialogTitle = axiosResponse.statusText || 'Error';
             useErrorDialog.dialogMsg = axiosResponse.data.detail;
             useErrorDialog.isErrorVisible = true;
         }


### PR DESCRIPTION
- add a default error title for error dialog refs: #739
- add the style change in the common theme repo