### PR TITLE
fix: #825 403 error interceptor

### DIFF
--- a/frontend/src/components/grantaccess/Summary.vue
+++ b/frontend/src/components/grantaccess/Summary.vue
@@ -31,11 +31,11 @@ async function handleSubmit() {
             grantAccessFormData.value as FamUserRoleAssignmentCreate
         );
         useNotificationMessage.isNotificationVisible = true;
+        router.push('/dashboard');
+        resetGrantAccessFormData();
     } catch (err: any) {
         return Promise.reject(err);
     } finally {
-        router.push('/dashboard');
-        resetGrantAccessFormData();
         loading.value = false;
     }
 }

--- a/frontend/src/services/http/HttpCommon.ts
+++ b/frontend/src/services/http/HttpCommon.ts
@@ -36,9 +36,5 @@ httpInstance.interceptors.response.use(
     (response) => response,
     HttpResInterceptors.authenticationErrorResponsesItcpt
 ); // 401 error handler
-httpInstance.interceptors.response.use(
-    (response) => response,
-    HttpResInterceptors.forbiddenErrorResponseItcpt
-); // 403 error handler
 
 export default httpInstance;

--- a/frontend/src/services/http/HttpResponseInterceptors.ts
+++ b/frontend/src/services/http/HttpResponseInterceptors.ts
@@ -33,14 +33,6 @@ async function authenticationErrorResponsesItcpt(error: any) {
     return Promise.reject(error); // return error for next interceptor.
 }
 
-// 403 Interceptor
-async function forbiddenErrorResponseItcpt(error: any) {
-    if (error.response?.status == 403) {
-        router.replace('/dashboard'); // Unauthorized operation, direct back to dashboard.
-    }
-    return Promise.reject(error);
-}
-
 async function refreshTokenAndReTry(
     config: AxiosRequestConfig,
     response: AxiosResponse
@@ -66,5 +58,4 @@ async function refreshTokenAndReTry(
 
 export default {
     authenticationErrorResponsesItcpt,
-    forbiddenErrorResponseItcpt,
 };


### PR DESCRIPTION
When self-granting error or any 403 error happens, app should stay on the same page and not redirect to the Dashboard.

Previously, there was a Http response interceptor that redirected all 403 errors to the Dashboard. This interceptor has been removed, so the user stays at the page that originated the 403 error.