### PR TITLE
spike: 742 per-route guard exemple

### DIFF
--- a/frontend/src/components/dashboard/DashboardTitle.vue
+++ b/frontend/src/components/dashboard/DashboardTitle.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import router from '@/router';
 import { IconSize } from '@/enum/IconEnum';
+import { loadingData } from '@/router/GrantAccessGuards';
 
 const props = defineProps({
     isApplicationSelected: {
@@ -9,6 +10,11 @@ const props = defineProps({
         default: false,
     },
 });
+
+const handleClick = () => {
+    loadingData.value = true;
+    router.push('/grant');
+};
 </script>
 
 <template>
@@ -20,8 +26,8 @@ const props = defineProps({
             <Button
                 v-if="props.isApplicationSelected"
                 class="dashboard-button"
-                label="Grant new access"
-                @click="router.push('/grant')"
+                :label="loadingData ? 'Loading...' : 'Grant new access'"
+                @click="handleClick"
             >
                 <Icon icon="add" :size="IconSize.medium" />
             </Button>

--- a/frontend/src/router/GrantAccessGuards.ts
+++ b/frontend/src/router/GrantAccessGuards.ts
@@ -1,0 +1,61 @@
+import { toRaw, ref } from 'vue';
+import authService from '@/services/AuthService';
+import { ApiServiceFactory } from '@/services/ApiServiceFactory';
+
+import {
+    domainOptions,
+    getGrantAccessFormData,
+    grantAccessFormData,
+    resetGrantAccessFormData,
+} from '@/store/GrantAccessDataState';
+
+import { selectedApplication } from '@/store/ApplicationState';
+
+import type { FamApplicationRole } from 'fam-api';
+
+let applicationRoleOptions: FamApplicationRole[];
+const loadingData = ref(false);
+const apiServiceFactory = new ApiServiceFactory();
+const applicationsApi = apiServiceFactory.getApplicationApi();
+const roles = toRaw(authService.state.value.famLoginUser!.roles);
+console.log(roles);
+
+const defaultFormData = {
+    domain: domainOptions.IDIR,
+    userId: '',
+    forestClientNumber: '',
+    role_id: null as number | null,
+};
+
+const formData = ref(JSON.parse(JSON.stringify(defaultFormData))); // clone default input
+
+function resetForm() {
+    resetGrantAccessFormData();
+    formData.value = defaultFormData;
+}
+
+const getApplicationRoles = async (to, from, next) => {
+    //setTimeout just to show explicitly that the guard is waiting
+    setTimeout(async () => {
+        try {
+            applicationRoleOptions = (
+                await applicationsApi.getFamApplicationRoles(
+                    selectedApplication.value?.application_id as number
+                )
+            ).data;
+
+            if (grantAccessFormData.value) {
+                formData.value = getGrantAccessFormData();
+            } else {
+                resetForm();
+            }
+        } catch (error: unknown) {
+            return Promise.reject(error);
+        } finally {
+            console.log(loadingData.value);
+            next();
+        }
+    }, 3000);
+};
+
+export { getApplicationRoles, resetForm, applicationRoleOptions, loadingData };

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -7,6 +7,7 @@ import GrantAccessView from '@/views/GrantAccessView.vue';
 import LandingView from '@/views/LandingView.vue';
 import DashboardView from '@/views/DashboardView.vue';
 import SummaryView from '@/views/SummaryView.vue';
+import { getApplicationRoles } from './GrantAccessGuards';
 
 // WARNING: any components referenced below that themselves reference the router cannot be automatically hot-reloaded in local development due to circular dependency
 // See vitejs issue https://github.com/vitejs/vite/issues/3033 for discussion.
@@ -27,7 +28,7 @@ const routes = [
         name: 'landing',
         meta: {
             title: 'Welcome to FAM',
-            layout: 'SimpleLayout'
+            layout: 'SimpleLayout',
         },
         component: LandingView,
     },
@@ -36,7 +37,7 @@ const routes = [
         name: 'dashboard',
         meta: {
             title: 'Dashboard',
-            layout: 'ProtectedLayout'
+            layout: 'ProtectedLayout',
         },
         component: DashboardView,
     },
@@ -45,16 +46,21 @@ const routes = [
         name: 'grant',
         meta: {
             title: 'Grant Access',
-            layout: 'ProtectedLayout'
+            layout: 'ProtectedLayout',
+            isRequiredAuth: true,
         },
         component: GrantAccessView,
+        // beforeEnter: [getApplicationRoles(to, from, next)]
+        beforeEnter: (to, from, next) => {
+            getApplicationRoles(to, from, next);
+        },
     },
     {
         path: '/summary',
         name: 'summary',
         meta: {
             title: 'Access request summary',
-            layout: 'ProtectedLayout'
+            layout: 'ProtectedLayout',
         },
         component: SummaryView,
     },


### PR DESCRIPTION
- Per-route guard on grantAccess page
- Used setTimeout to make sure that it would stay on dashboard until the function finished running since it was so quickly that was almost unnoticeable.

side note: Primevue have components such as ProgressSpinner and blockUi that might come in handy while the guard is doing it's function.

I made the simplest guard exemple a could and I'm available to answer any questions.