### PR TITLE
fix: #720 make user attribute displayname and email writable 

### DIFF
--- a/infrastructure/server/oidc_clients_fam.tf
+++ b/infrastructure/server/oidc_clients_fam.tf
@@ -22,7 +22,7 @@ resource "aws_cognito_user_pool_client" "fam_console_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = var.minimum_oidc_attribute_list
+  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
 
   depends_on = [
     aws_cognito_identity_provider.dev_idir_oidc_provider,

--- a/infrastructure/server/oidc_clients_silva.tf
+++ b/infrastructure/server/oidc_clients_silva.tf
@@ -31,7 +31,7 @@ resource "aws_cognito_user_pool_client" "dev_silva_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
 }
 
 resource "aws_cognito_user_pool_client" "test_silva_oidc_client" {
@@ -69,7 +69,7 @@ resource "aws_cognito_user_pool_client" "test_silva_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
 }
 
 resource "aws_cognito_user_pool_client" "prod_silva_oidc_client" {
@@ -107,5 +107,5 @@ resource "aws_cognito_user_pool_client" "prod_silva_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
 }


### PR DESCRIPTION
We need to make the user attributes both readable and writable in order to let Cognito update the user record and return the information back to the application, #720 