### PR TITLE
ci: swap out unmaintained action

### DIFF
--- a/.github/workflows/reusable_terraform_frontend.yml
+++ b/.github/workflows/reusable_terraform_frontend.yml
@@ -49,7 +49,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terragrunt
-        uses: peter-murray/terragrunt-github-action@v1.0.0
+        uses: autero1/action-terragrunt@v1.3.2/terragrunt-github-action@v1.0.0
         with:
           terragrunt_version: ${{ env.TG_VERSION }}
 

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -118,7 +118,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terragrunt
-        uses: peter-murray/terragrunt-github-action@v1.0.0
+        uses: autero1/action-terragrunt@v1.3.2/terragrunt-github-action@v1.0.0
         with:
           terragrunt_version: ${{ env.TG_VERSION }}
 


### PR DESCRIPTION
Deprecations in unmaintained action.
https://github.com/peter-murray/terragrunt-github-action

Replacing with action it was forked from.
https://github.com/autero1/action-terragrunt

Blog about deprecation.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fail example.
https://github.com/bcgov/nr-forests-access-management/actions/runs/6499302008/job/17652383720#step:10:25