### PR TITLE
ci: update checkout action for node 12 deprecation

### DIFF
--- a/.github/workflows/ci_auth_artifact.yml
+++ b/.github/workflows/ci_auth_artifact.yml
@@ -15,7 +15,7 @@ jobs:
   auth-function-ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Auth function zip
         run: |

--- a/.github/workflows/reusable_terraform_frontend.yml
+++ b/.github/workflows/reusable_terraform_frontend.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.5.0
 
       - name: Build Frontend
         working-directory: frontend

--- a/.github/workflows/reusable_terraform_frontend.yml
+++ b/.github/workflows/reusable_terraform_frontend.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.5.0
+        uses: actions/checkout@v4
 
       - name: Build Frontend
         working-directory: frontend

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.5.0
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.5.0
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,7 +13,7 @@ jobs:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Deep fetch is required for SonarCloud
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
       POSTGRES_PORT: 5432
       USE_POSTGRES: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Deep fetch is required for SonarCloud
           fetch-depth: 0


### PR DESCRIPTION
Node 12 has been deprecated.  Actions using it will stop working when GitHub eventually pulls the plug in their runners.

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

![Screenshot_20231012_115130](https://github.com/bcgov/nr-forests-access-management/assets/4391600/1ccf62f4-67d9-4405-af37-55d3322002b0)
