### PR TITLE
ci: Update actions/upload-artifact action to v3

### DIFF
--- a/.github/workflows/ci_auth_artifact.yml
+++ b/.github/workflows/ci_auth_artifact.yml
@@ -28,7 +28,7 @@ jobs:
           rm -rf auth_function_packaging
 
       - name: Auth function upload zip file artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: fam-auth-function-zip
           path: ./infrastructure/server/fam_auth_function.zip

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -76,7 +76,7 @@ jobs:
           rm -rf auth_function_packaging
 
       - name: Auth function upload zip file artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: fam-auth-function
           path: ./infrastructure/server/fam_auth_function.zip
@@ -99,7 +99,7 @@ jobs:
           cd ..
 
       - name: Upload zip file artifact - FAM API
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: fam-ui-api
           path: ./infrastructure/server/fam-ui-api.zip


### PR DESCRIPTION
The warning below is found during most current deployment from Github:
![image](https://github.com/bcgov/nr-forests-access-management/assets/81595625/4a081168-597a-4b8e-9170-83b714b2fa15)

Update the action to v3.