### PR TITLE
fix: #987 add missing type check router guards

### DIFF
--- a/server/backend/api/app/routers/router_guards.py
+++ b/server/backend/api/app/routers/router_guards.py
@@ -46,7 +46,7 @@ external_user_prohibited_exception = HTTPException(
 )
 
 def authorize_by_app_id(
-    application_id,
+    application_id: int,
     db: Session = Depends(database.get_db),
     claims: dict = Depends(validate_token)
 ):


### PR DESCRIPTION
- Add missing type for `application_id` at `router_guards::authorize_by_app_id()` which failed Pythone type check.
- Add test to capture the router response when application_id is an invalid `str` type.