### PR TITLE
fix: #993 user name field consistency

### DIFF
--- a/server/backend/api/app/crud/crud_user.py
+++ b/server/backend/api/app/crud/crud_user.py
@@ -1,7 +1,7 @@
 import logging
 
 from api.app.models import model as models
-from sqlalchemy.orm import Session, load_only
+from sqlalchemy.orm import Session
 
 from .. import schemas
 

--- a/server/backend/api/app/crud/crud_user_role.py
+++ b/server/backend/api/app/crud/crud_user_role.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from api.app import constants as famConstants
 from api.app.models import model as models
 from api.app.integration.forest_client.forest_client import ForestClientService
-from sqlalchemy.orm import Session, load_only
+from sqlalchemy.orm import Session
 
 from .. import schemas
 from . import crud_forest_client, crud_role, crud_user, crud_utils

--- a/server/backend/api/app/integration/idim_proxy.py
+++ b/server/backend/api/app/integration/idim_proxy.py
@@ -8,6 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 REQUESTER_ACCOUNT_TYPE_INTERNAL = "Internal"
 
+
 class IdimProxyService():
     """
     The class is used for making requests to search IDIR/BCeID information from IDIM Proxy API.

--- a/server/backend/api/app/routers/router_idim_proxy.py
+++ b/server/backend/api/app/routers/router_idim_proxy.py
@@ -14,7 +14,7 @@ router = APIRouter()
 
 @router.get("/idir", response_model=IdimProxyIdirInfo, dependencies=[Depends(internal_only_action)])
 def idir_search(
-    user_id: str = Query(max_length=15),
+    user_id: str = Query(max_length=20),
     # user_id: str = Annotated[str, Query(max_length=15)], # Although 'Annotated' is recommended by FastAPI, however, using Annotated has a bug
                                                            # It will throw pydantic.error_wrappers.ValidationError which is 500, not 422 we need.
                                                            # known issue: https://github.com/tiangolo/fastapi/issues/4974

--- a/server/backend/api/app/schemas.py
+++ b/server/backend/api/app/schemas.py
@@ -61,7 +61,7 @@ class FamApplication(FamApplicationCreate):
 class FamUser(BaseModel):
     user_type_code: famConstants.UserType
     cognito_user_id: Optional[Annotated[str, StringConstraints(max_length=100)]] = None  # temporarily optional
-    user_name: Annotated[str, StringConstraints(max_length=100)]
+    user_name: Annotated[str, StringConstraints(max_length=20)]
     user_guid: Optional[Annotated[str, StringConstraints(max_length=32)]] = None
     create_user: Annotated[str, StringConstraints(max_length=60)]
     update_user: Optional[Annotated[str, StringConstraints(max_length=60)]] = None
@@ -81,7 +81,7 @@ class FamRoleTypeGet(BaseModel):
 
 # Role assignment with one role at a time for the user.
 class FamUserRoleAssignmentCreate(BaseModel):
-    user_name: Annotated[str, StringConstraints(min_length=3, max_length=100)] # db max length
+    user_name: Annotated[str, StringConstraints(min_length=3, max_length=20)] # IDIM search max length
     user_type_code: famConstants.UserType
     role_id: int
     forest_client_number: Union[
@@ -258,13 +258,13 @@ class FamApplicationUserRoleAssignmentGet(FamUserRoleAssignmentGet):
 
 
 class IdimProxySearchParamIdir(BaseModel):
-    userId: Annotated[str, StringConstraints(max_length=15)]  # param for Idim-Proxy search of this form (not snake case)
+    userId: Annotated[str, StringConstraints(max_length=20)]  # param for Idim-Proxy search of this form (not snake case)
 
 
 class IdimProxyIdirInfo(BaseModel):
     # property returned from Idim-Proxy search of this form (not snake case)
     found: bool
-    userId: Optional[Annotated[str, StringConstraints(max_length=15)]] = None
+    userId: Optional[Annotated[str, StringConstraints(max_length=20)]] = None
     displayName: Optional[Annotated[str, StringConstraints(max_length=50)]] = None
 
     @staticmethod
@@ -278,7 +278,7 @@ class IdimProxyIdirInfo(BaseModel):
 
 
 class GCNotifyGrantAccessEmailParam(BaseModel):
-    user_name: Annotated[str, StringConstraints(max_length=15)]
+    user_name: Annotated[str, StringConstraints(max_length=20)]
     application_name: Annotated[str, StringConstraints(max_length=35)]
     send_to_email: EmailStr
 
@@ -293,12 +293,13 @@ class Requester(BaseModel):
     """
     # cognito_user_id => Cognito OIDC access token maps this to: username (ID token => "custom:idp_name" )
     cognito_user_id: Union[str, None] = None
-    user_name: Annotated[str, StringConstraints(max_length=15)]
+    user_name: Annotated[str, StringConstraints(max_length=20)]
     # "B"(BCeID) or "I"(IDIR). It is the IDP provider.
     user_type_code: Union[famConstants.UserType, None] = None
     access_roles: Union[List[Annotated[str, StringConstraints(max_length=50)]], None] = None
 
     model_config = ConfigDict(from_attributes=True)
+
 
 class TargetUser(Requester):
     pass

--- a/server/backend/testspg/crud/test_idim_proxy_service.py
+++ b/server/backend/testspg/crud/test_idim_proxy_service.py
@@ -5,10 +5,10 @@ import logging
 import pytest
 from api.app.integration.idim_proxy import IdimProxyService
 from api.app.schemas import IdimProxySearchParamIdir, Requester
-from api.app.utils.utils import read_json_file
 from requests import HTTPError
 
 LOGGER = logging.getLogger(__name__)
+
 
 class TestIdimProxyServiceClass(object):
     """

--- a/server/backend/testspg/router/test_router_idim_proxy.py
+++ b/server/backend/testspg/router/test_router_idim_proxy.py
@@ -2,13 +2,11 @@ import logging
 from http import HTTPStatus
 
 import testspg.jwt_utils as jwt_utils
-from api.app import jwt_validation
 from api.app.constants import UserType
 from api.app.main import apiPrefix
 from api.app.routers.router_guards import (get_current_requester,
                                            no_requester_exception)
 from api.app.schemas import Requester
-from api.app.utils.utils import read_json_file
 from fastapi.testclient import TestClient
 from testspg.conftest import test_client_fixture
 
@@ -26,11 +24,13 @@ sample_idir_requester_dict = {
     "access_roles": ["FAM_ACCESS_ADMIN", "FOM_DEV_ACCESS_ADMIN"]
 }
 
+
 async def mock_get_current_requester_with_idir_user():
     """
     A mock for router dependency, for requester who is IDIR user.
     """
     return Requester(**sample_idir_requester_dict)
+
 
 async def mock_get_current_requester_with_none_idir_user():
     """
@@ -39,6 +39,7 @@ async def mock_get_current_requester_with_none_idir_user():
     none_idir_requester = sample_idir_requester_dict
     none_idir_requester["user_type_code"] = UserType.BCEID # Set to none-IDIR
     return Requester(**none_idir_requester)
+
 
 async def mock_get_current_requester_user_not_exists():
     """
@@ -67,6 +68,7 @@ def test_search_idir_with_valid_user_found_result(
     assert response.json()['found'] == True
     assert response.json()['userId'] == valid_user_id_param
 
+
 def test_search_idir_with_invalid_user_return_not_found(
     test_client_fixture: test_client_fixture,
     test_rsa_key
@@ -88,6 +90,7 @@ def test_search_idir_with_invalid_user_return_not_found(
     assert response.json()['found'] == False
     assert response.json()['userId'] == invalid_user_id_param
 
+
 def test_none_idir_user_cannot_search_idir_user(
     test_client_fixture: TestClient,
     test_rsa_key
@@ -107,6 +110,7 @@ def test_none_idir_user_cannot_search_idir_user(
 
     assert response.status_code == HTTPStatus.FORBIDDEN
     assert "Action is not allowed for external user." in response.text
+
 
 def test_search_idir_user_requester_not_found_error_raised(
     test_client_fixture: TestClient,


### PR DESCRIPTION
For task #993 
* Align `user_name` and `userId` to max length 20 (frontend already has 20 in max). IDIM doc has the max as 20.
* Changes are on `router_idim_proxy.py` and `schemas.py`, others just some formatting adjustment.