### PR TITLE
ci: renovate extends bcgov/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "prConcurrentLimit": 5
+  "description": "Presets from https://github.com/bcgov/nr-renovate",
+  "extends": [
+    "github>bcgov/renovate-config"
+  ]
 }


### PR DESCRIPTION
Updated renovate.json.  Extends from bcgov/renovate-config.  Can be used with the Renovate GitHub app, which our upstream jobs are being replaced by.