### PR TITLE
fix: #1097 add route security

### DIFF
--- a/frontend/src/components/common/ToastMessage.vue
+++ b/frontend/src/components/common/ToastMessage.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { IconSize } from '@/enum/IconEnum';
 import { app } from '@/main';
-import { getToastErrorMsg, routeToastError, setRouteToastError, useToastService } from '@/store/ToastState';
+import {
+    getToastErrorMsg,
+    routeToastError,
+    setRouteToastError,
+    useToastService,
+} from '@/store/ToastState';
 import Toast, { type ToastMessageOptions } from 'primevue/toast';
 import { watch } from 'vue';
 
@@ -20,13 +25,16 @@ watch(routeToastError, (value) => {
 
 const handleToastTimeoutEnds = (message: ToastMessageOptions) => {
     setRouteToastError(undefined); // clear routeToastError state
-}
-
+};
 </script>
 
 <template>
-    <Toast group="tl" position="top-right" #icon
-        @life-end="handleToastTimeoutEnds">
+    <Toast
+        group="tl"
+        position="top-right"
+        #icon
+        @life-end="handleToastTimeoutEnds"
+    >
         <Icon
             icon="error--filled"
             :size="IconSize.large"

--- a/frontend/src/components/common/ToastMessage.vue
+++ b/frontend/src/components/common/ToastMessage.vue
@@ -1,77 +1,32 @@
 <script setup lang="ts">
-import { app } from '@/main';
-import axios from 'axios';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
 import { IconSize } from '@/enum/IconEnum';
+import { app } from '@/main';
+import { getToastErrorMsg, routeToastError, setRouteToastError, useToastService } from '@/store/ToastState';
+import Toast, { type ToastMessageOptions } from 'primevue/toast';
+import { watch } from 'vue';
 
-const toast = useToast();
+const { showToastErrorTopRight } = useToastService();
 
-const showToastTopRight = (sev: any, title: string, text: string) => {
-    toast.add({ severity: sev, summary: title, detail: text, group: 'tl' });
+app.config.errorHandler = (err) => {
+    showToastErrorTopRight(getToastErrorMsg(err));
 };
 
-const onError = (error: any, info: string) => {
-    console.error(`Error occurred: ${error.toString()}`);
-    const genericErrorMsg = {
-        title: 'Error',
-        text: 'An application error has occurred. Please try again. If the error persists contact support.',
-    };
-
-    // Axios Http instance error that we like to pop out additional toast message.
-    if (axios.isAxiosError(error)) {
-        const err = error;
-        const axiosResponse = err.response;
-        const status = axiosResponse?.status;
-
-        const e401_authenticationErrorMsg = {
-            title: 'Error',
-            text: 'You are not logged in. Please log in.',
-        };
-
-        const e403_authorizationErrorMsg = {
-            title: 'Error',
-            text: 'You do not have the necessary authorization for the requested action.',
-        };
-
-        if (!status) {
-            showToastTopRight(
-                'error',
-                genericErrorMsg.title,
-                genericErrorMsg.text
-            );
-        } else if (status == 401) {
-            showToastTopRight(
-                'error',
-                e401_authenticationErrorMsg.title,
-                e401_authenticationErrorMsg.text
-            );
-        } else if (status == 403) {
-            showToastTopRight(
-                'error',
-                e403_authorizationErrorMsg.title,
-                e403_authorizationErrorMsg.text
-            );
-        } else if (status == 409) {
-            showToastTopRight(
-                'error',
-                genericErrorMsg.title,
-                axiosResponse?.data.detail
-            );
-        }
-        return;
+// Watch RouteError state change and popup toast if needed.
+watch(routeToastError, (value) => {
+    if (value) {
+        showToastErrorTopRight(getToastErrorMsg(value));
     }
+});
 
-    showToastTopRight('error', genericErrorMsg.title, genericErrorMsg.text);
-};
+const handleToastTimeoutEnds = (message: ToastMessageOptions) => {
+    setRouteToastError(undefined); // clear routeToastError state
+}
 
-app.config.errorHandler = (err, instance, info) => {
-    onError(err, info);
-};
 </script>
 
 <template>
-    <Toast group="tl" position="top-right" #icon>
+    <Toast group="tl" position="top-right" #icon
+        @life-end="handleToastTimeoutEnds">
         <Icon
             icon="error--filled"
             :size="IconSize.large"

--- a/frontend/src/errors/FamCustomError.ts
+++ b/frontend/src/errors/FamCustomError.ts
@@ -1,0 +1,33 @@
+// Custom FAM parent error.
+export class FamCustomError extends Error {
+    message: string;
+    cause: Error | undefined; // Original error if any.
+    constructor(message: string, caues?: Error) {
+        super(message);
+        this.message = message;
+        this.cause = caues;
+    }
+}
+
+// --- FamRouteError
+
+export enum RouteErrorName {
+    NOT_AUTHENTICATED_ERROR = 'NOT_AUTHENTICATED_ERROR',
+    NO_APPLICATION_SELECTED_ERROR = 'NO_APPLICATION_SELECTED_ERROR'
+}
+
+type RouteInfo = {to: any, from: any};
+/**
+ * FAM custom route error.
+ * For use only when needing to throw during router transition.
+ */
+export class FamRouteError extends FamCustomError {
+    name: RouteErrorName;
+    routeInfo: RouteInfo | undefined;
+
+    constructor(name: RouteErrorName, message: string, routeInfo?: RouteInfo, caues?: Error) {
+        super(message, caues);
+        this.name = name;
+        this.routeInfo = routeInfo;
+    }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,7 +2,10 @@ import { createRouter, createWebHistory } from 'vue-router';
 
 import AuthCallback from '@/components/AuthCallbackHandler.vue';
 import NotFound from '@/components/NotFound.vue';
-import { beforeEachRouteHandler, beforeEnterHandlers } from '@/router/routeHandlers';
+import {
+    beforeEachRouteHandler,
+    beforeEnterHandlers,
+} from '@/router/routeHandlers';
 import { routeItems } from '@/router/routeItem';
 import GrantAccessView from '@/views/GrantAccessView.vue';
 import LandingView from '@/views/LandingView.vue';

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,15 +2,8 @@ import { createRouter, createWebHistory } from 'vue-router';
 
 import AuthCallback from '@/components/AuthCallbackHandler.vue';
 import NotFound from '@/components/NotFound.vue';
-import { beforeEachRouteHandler } from '@/router/routeHandlers';
+import { beforeEachRouteHandler, beforeEnterHandlers } from '@/router/routeHandlers';
 import { routeItems } from '@/router/routeItem';
-import {
-    fetchApplicationRoles,
-    fetchApplications,
-    fetchUserRoleAssignments,
-} from '@/services/fetchData';
-import { selectedApplication } from '@/store/ApplicationState';
-import { populateBreadcrumb } from '@/store/BreadcrumbState';
 import GrantAccessView from '@/views/GrantAccessView.vue';
 import LandingView from '@/views/LandingView.vue';
 import ManagePermissionsView from '@/views/ManagePermissionsView.vue';
@@ -41,7 +34,7 @@ import ManagePermissionsView from '@/views/ManagePermissionsView.vue';
 const routes = [
     {
         path: '/',
-        name: 'landing',
+        name: routeItems.landing.name,
         meta: {
             requiresAuth: false,
             title: 'Welcome to FAM',
@@ -52,7 +45,7 @@ const routes = [
     },
     {
         path: routeItems.dashboard.path,
-        name: routeItems.dashboard.label,
+        name: routeItems.dashboard.name,
         meta: {
             requiresAuth: true,
             title: routeItems.dashboard.label,
@@ -60,15 +53,7 @@ const routes = [
             hasBreadcrumb: false,
         },
         component: ManagePermissionsView,
-        beforeEnter: async (to: any) => {
-            // Requires fetching applications the user administers.
-            await fetchApplications();
-            const userRoleAssignments = await fetchUserRoleAssignments(
-                selectedApplication.value?.application_id
-            );
-            Object.assign(to.meta, { userRoleAssignments: userRoleAssignments });
-            return true;
-        },
+        beforeEnter: beforeEnterHandlers[routeItems.dashboard.name],
         props: (route: any) => {
             return {
                 // userRoleAssignments is ready for the `component` as props.
@@ -77,29 +62,17 @@ const routes = [
         },
     },
     {
-        path: routeItems.addUserPermission.path,
-        name: routeItems.addUserPermission.label,
+        path: routeItems.grantUserPermission.path,
+        name: routeItems.grantUserPermission.name,
         meta: {
             requiresAuth: true,
             requiresAppSelected: true,
-            title: routeItems.addUserPermission.label,
+            title: routeItems.grantUserPermission.label,
             layout: 'ProtectedLayout',
             hasBreadcrumb: true,
         },
         component: GrantAccessView,
-        beforeEnter: async (to: any) => {
-            populateBreadcrumb([
-                routeItems.dashboard,
-                routeItems.addUserPermission,
-            ]);
-            // Passing fetched data to router.meta (so it is available for assigning to 'props' later)
-            Object.assign(to.meta, {
-                applicationRoleOptions: await fetchApplicationRoles(
-                    selectedApplication.value!.application_id
-                ),
-            });
-            return true;
-        },
+        beforeEnter: beforeEnterHandlers[routeItems.grantUserPermission.name],
         props: (route: any) => {
             return {
                 // options is ready for the `component` as props.

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -153,7 +153,6 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from) => {
-
     // Authentication guard. Always check first.
     if (to.meta.requiresAuth && !AuthService.getters.isLoggedIn()) {
         return {path: routeItems.landing.path}
@@ -164,7 +163,7 @@ router.beforeEach(async (to, from) => {
         return {path: routeItems.dashboard.path}
     }
 
-    // Refresh token first before navigation.
+    // Refresh token before navigation.
     if (AuthService.state.value.famLoginUser) {
         // condition needed to prevent infinite redirect
         await AuthService.methods.refreshToken();

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,17 +2,19 @@ import { createRouter, createWebHistory } from 'vue-router';
 
 import AuthCallback from '@/components/AuthCallbackHandler.vue';
 import NotFound from '@/components/NotFound.vue';
+import { FamRouteError, RouteErrorName } from '@/errors/FamCustomError';
 import AuthService from '@/services/AuthService';
-import GrantAccessView from '@/views/GrantAccessView.vue';
-import LandingView from '@/views/LandingView.vue';
-import ManagePermissionsView from '@/views/ManagePermissionsView.vue';
-import { populateBreadcrumb } from '@/store/BreadcrumbState';
 import {
     fetchApplicationRoles,
     fetchApplications,
     fetchUserRoleAssignments,
 } from '@/services/fetchData';
 import { isApplicationSelected, selectedApplication } from '@/store/ApplicationState';
+import { populateBreadcrumb } from '@/store/BreadcrumbState';
+import { setRouteToastError as emitRouteToastError } from '@/store/ToastState';
+import GrantAccessView from '@/views/GrantAccessView.vue';
+import LandingView from '@/views/LandingView.vue';
+import ManagePermissionsView from '@/views/ManagePermissionsView.vue';
 
 // WARNING: any components referenced below that themselves reference the router cannot be automatically hot-reloaded in local development due to circular dependency
 // See vitejs issue https://github.com/vitejs/vite/issues/3033 for discussion.
@@ -155,12 +157,29 @@ const router = createRouter({
 router.beforeEach(async (to, from) => {
     // Authentication guard. Always check first.
     if (to.meta.requiresAuth && !AuthService.getters.isLoggedIn()) {
+        const routeError = new FamRouteError(
+            RouteErrorName.NOT_AUTHENTICATED_ERROR,
+            "You're not login",
+            {to, from}
+        )
+        emitRouteToastError(routeError);
         return {path: routeItems.landing.path}
     }
 
     // Application selected guard.
     if (to.meta.requiresAppSelected && !isApplicationSelected.value) {
-        return {path: routeItems.dashboard.path}
+
+        // Only to compose this custom error, but not to throw.
+        // Due to throwing error from router cannot be caught by Primevue toast.
+        // The RouteError will be emitted to a state.
+        const routeError = new FamRouteError(
+            RouteErrorName.NO_APPLICATION_SELECTED_ERROR,
+            'No application is Selected',
+            {to, from}
+        )
+        emitRouteToastError(routeError);
+        // Back to dashboard after emit error.
+        return {path: routeItems.dashboard.path};
     }
 
     // Refresh token before navigation.

--- a/frontend/src/router/routeHandlers.ts
+++ b/frontend/src/router/routeHandlers.ts
@@ -1,0 +1,46 @@
+import { FamRouteError, RouteErrorName } from "@/errors/FamCustomError";
+import { routeItems } from '@/router/routeItem';
+import AuthService from "@/services/AuthService";
+import { isApplicationSelected } from "@/store/ApplicationState";
+import { setRouteToastError as emitRouteToastError } from '@/store/ToastState';
+import type { RouteLocationNormalized } from "vue-router";
+
+// Route `beforeEach` handler.
+// Responsible for route guards and necessary operations before each route.
+export const beforeEachRouteHandler = async (
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized) => {
+
+    // Authentication guard. Always check first.
+    if (to.meta.requiresAuth && !AuthService.getters.isLoggedIn()) {
+        // Only to compose this custom error, but not to throw.
+        // Due to throwing error from router cannot be caught by Primevue toast.
+        // The RouteError will be emitted to a state.
+        const routeError = new FamRouteError(
+            RouteErrorName.NOT_AUTHENTICATED_ERROR,
+            "You're not login",
+            {to, from}
+        )
+        emitRouteToastError(routeError);
+        // Back to Landing after emit error.
+        return {path: routeItems.landing.path}
+    }
+
+    // Application selected guard.
+    if (to.meta.requiresAppSelected && !isApplicationSelected.value) {
+        const routeError = new FamRouteError(
+            RouteErrorName.NO_APPLICATION_SELECTED_ERROR,
+            'No application is Selected',
+            {to, from}
+        )
+        emitRouteToastError(routeError);
+        // Back to dashboard after emit error.
+        return {path: routeItems.dashboard.path};
+    }
+
+    // Refresh token before navigation.
+    if (AuthService.state.value.famLoginUser) {
+        // condition needed to prevent infinite redirect
+        await AuthService.methods.refreshToken();
+    }
+}

--- a/frontend/src/router/routeItem.ts
+++ b/frontend/src/router/routeItem.ts
@@ -1,0 +1,23 @@
+export interface IRouteInfo {
+    label: string;
+    path: string;
+}
+
+export type RouteItems = {
+    [key: string]: IRouteInfo;
+};
+
+export const routeItems = {
+    landing: {
+        path: '/',
+        label: 'Welcome to FAM',
+    },
+    dashboard: {
+        path: '/dashboard',
+        label: 'Manage permissions',
+    },
+    addUserPermission: {
+        path: '/grant',
+        label: 'Add user permission',
+    },
+} as RouteItems;

--- a/frontend/src/router/routeItem.ts
+++ b/frontend/src/router/routeItem.ts
@@ -1,6 +1,7 @@
 export interface IRouteInfo {
     label: string;
     path: string;
+    name: string;
 }
 
 export type RouteItems = {
@@ -9,14 +10,17 @@ export type RouteItems = {
 
 export const routeItems = {
     landing: {
+        name: 'landing',
         path: '/',
         label: 'Welcome to FAM',
     },
     dashboard: {
+        name: 'dashboard',
         path: '/dashboard',
         label: 'Manage permissions',
     },
-    addUserPermission: {
+    grantUserPermission: {
+        name: 'grantUserPermission',
         path: '/grant',
         label: 'Add user permission',
     },

--- a/frontend/src/services/fetchData.ts
+++ b/frontend/src/services/fetchData.ts
@@ -57,10 +57,8 @@ export const deletAndRefreshUserRoleAssignments = async (
 };
 
 export const fetchApplicationRoles = async (
-    applicationId: number | undefined
+    applicationId: number
 ) => {
-    if (!applicationId) return;
-
     const applicationRoles = (
         await AppActlApiService.applicationsApi.getFamApplicationRoles(
             applicationId

--- a/frontend/src/services/utils.ts
+++ b/frontend/src/services/utils.ts
@@ -1,0 +1,16 @@
+
+/**
+ * This is for use in case if you need to warp normal async return
+ * (promise's resolve or reject) so you can await for it and use
+ * normal "if (data)/else { handle error}" than typical try-catch.
+ * @param promise Promise()
+ * @returns '{data, error}' in tuple containing 'data' (underfined when 'error' present).
+ */
+const asyncWrap = async (promise: Promise<any>) => {
+    try {
+        const data = await promise;
+        return {data, error: undefined};
+    } catch (error) {
+        return {data: undefined, error}
+    }
+}

--- a/frontend/src/services/utils.ts
+++ b/frontend/src/services/utils.ts
@@ -1,3 +1,7 @@
+type AsyncWrapType = {
+    data: any;
+    error: any;
+};
 
 /**
  * This is for use in case if you need to warp normal async return
@@ -6,7 +10,7 @@
  * @param promise Promise()
  * @returns '{data, error}' in tuple containing 'data' (underfined when 'error' present).
  */
-const asyncWrap = async (promise: Promise<any>) => {
+export const asyncWrap = async (promise: Promise<any>): Promise<AsyncWrapType> => {
     try {
         const data = await promise;
         return {data, error: undefined};

--- a/frontend/src/store/ToastState.ts
+++ b/frontend/src/store/ToastState.ts
@@ -3,18 +3,6 @@ import axios, { type AxiosError } from 'axios';
 import { useToast } from 'primevue/usetoast';
 import { ref } from 'vue';
 
-// the toastError state is just used to store the error before enter the router
-export const toastError = ref('');
-export const setToastError = (error: string) => {
-    toastError.value = error;
-};
-export const clearToastError = () => {
-    toastError.value = '';
-};
-
-// TODO: Below is similiar as above Catherine's good usage.
-// But with custom route error passing instead of string type.
-
 // A RotetoastError state. Special case for handling routing error that
 // cannot be caught from Vue.
 export const routeToastError = ref();
@@ -91,7 +79,3 @@ const handleRouteErrorMessage = (error: FamRouteError): string => {
     }
     return genericErrorMsg.text;
 }
-
-export const setToastErrorMsg = (error: any) => {
-    setToastError(getToastErrorMsg(error));
-};

--- a/frontend/src/store/ToastState.ts
+++ b/frontend/src/store/ToastState.ts
@@ -1,7 +1,7 @@
-import { ref } from 'vue';
-import axios from 'axios';
+import { FamRouteError, RouteErrorName } from '@/errors/FamCustomError';
+import axios, { type AxiosError } from 'axios';
 import { useToast } from 'primevue/usetoast';
-import { RouteErrorName, FamRouteError } from '@/errors/FamCustomError';
+import { ref } from 'vue';
 
 // the toastError state is just used to store the error before enter the router
 export const toastError = ref('');
@@ -13,12 +13,12 @@ export const clearToastError = () => {
 };
 
 // TODO: Below is similiar as above Catherine's good usage.
-// But with custom RouteError passing instead of string type.
+// But with custom route error passing instead of string type.
 
 // A RotetoastError state. Special case for handling routing error that
 // cannot be caught from Vue.
 export const routeToastError = ref();
-export const setRouteToastError = (error: FamRouteError | undefined) => {
+export const setRouteToastError = (error: FamRouteError | AxiosError | undefined) => {
     routeToastError.value = error;
 };
 
@@ -86,7 +86,7 @@ export const getToastErrorMsg = (error: any) => {
 
 const handleRouteErrorMessage = (error: FamRouteError): string => {
     if (RouteErrorName.NOT_AUTHENTICATED_ERROR == error.name ||
-        RouteErrorName.NO_APPLICATION_SELECTED_ERROR) {
+        RouteErrorName.NO_APPLICATION_SELECTED_ERROR == error.name) {
         return error.message;
     }
     return genericErrorMsg.text;

--- a/frontend/src/store/ToastState.ts
+++ b/frontend/src/store/ToastState.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 import axios from 'axios';
 import { useToast } from 'primevue/usetoast';
-import { RouteErrorName, FamRouteError } from '@/router/RouteError';
+import { RouteErrorName, FamRouteError } from '@/errors/FamCustomError';
 
 // the toastError state is just used to store the error before enter the router
 export const toastError = ref('');

--- a/frontend/src/store/ToastState.ts
+++ b/frontend/src/store/ToastState.ts
@@ -1,0 +1,96 @@
+import { ref } from 'vue';
+import axios from 'axios';
+import { useToast } from 'primevue/usetoast';
+import { RouteErrorName, FamRouteError } from '@/router/RouteError';
+
+// the toastError state is just used to store the error before enter the router
+export const toastError = ref('');
+export const setToastError = (error: string) => {
+    toastError.value = error;
+};
+export const clearToastError = () => {
+    toastError.value = '';
+};
+
+// TODO: Below is similiar as above Catherine's good usage.
+// But with custom RouteError passing instead of string type.
+
+// A RotetoastError state. Special case for handling routing error that
+// cannot be caught from Vue.
+export const routeToastError = ref();
+export const setRouteToastError = (error: FamRouteError | undefined) => {
+    routeToastError.value = error;
+};
+
+// the primevue toast can only be injected in setup or functional component,
+// in order to reuse the toast service,
+// we have to define it in the way as below
+// https://stackoverflow.com/questions/72425297/vue-warn-inject-can-only-be-used-inside-setup-or-functional-components
+export const useToastService = () => {
+    const toast = useToast();
+
+    const showToastErrorTopRight = (text: string) => {
+        toast.add({
+            severity: 'error',
+            summary: 'ERROR',
+            detail: text,
+            group: 'tl',
+            life: 5000 // delay before auto cleared.
+        });
+    };
+
+    return { showToastErrorTopRight };
+};
+
+const genericErrorMsg = {
+    title: 'Error',
+    text: 'An application error has occurred. Please try again. If the error persists contact support.',
+};
+
+export const getToastErrorMsg = (error: any) => {
+    console.error(`Error occurred: ${error.toString()}`);
+
+    // Axios Http instance error that we like to pop out additional toast message.
+    if (axios.isAxiosError(error)) {
+        const axiosResponse = error.response;
+        const status = axiosResponse?.status;
+
+        const e401_authenticationErrorMsg = {
+            title: 'Error',
+            text: 'You are not logged in. Please log in.',
+        };
+
+        const e403_authorizationErrorMsg = {
+            title: 'Error',
+            text: 'You do not have the necessary authorization for the requested action.',
+        };
+
+        if (!status) {
+            return genericErrorMsg.text;
+        } else if (status == 401) {
+            return e401_authenticationErrorMsg.text;
+        } else if (status == 403) {
+            return e403_authorizationErrorMsg.text;
+        } else if (status == 409) {
+            return axiosResponse?.data.detail;
+        }
+        return;
+    }
+
+    if (error instanceof FamRouteError) {
+        return handleRouteErrorMessage(error);
+    }
+
+    return genericErrorMsg.text;
+};
+
+const handleRouteErrorMessage = (error: FamRouteError): string => {
+    if (RouteErrorName.NO_APPLICATION_SELECTED_ERROR == error.name) {
+        return error.message;
+    }
+    return genericErrorMsg.text;
+}
+
+export const setToastErrorMsg = (error: any) => {
+    setToastError(getToastErrorMsg(error));
+};

--- a/frontend/src/store/ToastState.ts
+++ b/frontend/src/store/ToastState.ts
@@ -85,7 +85,8 @@ export const getToastErrorMsg = (error: any) => {
 };
 
 const handleRouteErrorMessage = (error: FamRouteError): string => {
-    if (RouteErrorName.NO_APPLICATION_SELECTED_ERROR == error.name) {
+    if (RouteErrorName.NOT_AUTHENTICATED_ERROR == error.name ||
+        RouteErrorName.NO_APPLICATION_SELECTED_ERROR) {
         return error.message;
     }
     return genericErrorMsg.text;


### PR DESCRIPTION
Add route security and handle route error for toast.

- if user does not login, and tries to access any protected pages, always redirect back to landing page, and show the error message like "you're not login"
- if user login without any role
    - ‘/dashboard’, show empty table and the error message something is like “don’t have the necessary authorization for the requested action”
    - ‘/grant’, because no application can be selected to grant, redirect to the ‘/dashboard’, the error in dashboard page will show