### PR TITLE
fix: fixing wrong import for Session

### DIFF
--- a/server/admin_management/api/app/routers/router_utils.py
+++ b/server/admin_management/api/app/routers/router_utils.py
@@ -1,12 +1,11 @@
 
 import logging
-from fastapi import Depends
-
-from requests import Session
 
 from api.app import database
-from api.app.services.application_service import ApplicationService
 from api.app.services.application_admin_service import ApplicationAdminService
+from api.app.services.application_service import ApplicationService
+from fastapi import Depends
+from sqlalchemy.orm import Session
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix one of the import (Session), which was wrong from `requests`, should be from `sqlalchemy.orm` 