### PR TITLE
fix: #1121 breadcrumb component not routing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
             "name": "fam-frontend",
             "version": "0.0.0",
             "dependencies": {
-                "@bcgov-nr/nr-theme": "^1.8.3",
+                "@bcgov-nr/nr-theme": "^1.8.4",
                 "@carbon/icons-vue": "^10.72.1",
                 "aws-amplify": "^5.3.6",
                 "axios": "1.6.5",
@@ -7638,9 +7638,9 @@
             }
         },
         "node_modules/@bcgov-nr/nr-theme": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/@bcgov-nr/nr-theme/-/nr-theme-1.8.3.tgz",
-            "integrity": "sha512-8RPcZew0TDM/Rek4nBgMwCoNl2iL+i+ksrBXhOLpgIco2Vagus7b+oB/99VNlIjktiNMUep9/be2f6/1TGgQrA=="
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/@bcgov-nr/nr-theme/-/nr-theme-1.8.4.tgz",
+            "integrity": "sha512-otXy8RsKZ1GdMIGlJRP5XvY5AdxkkNFI74DQYJ4hpz4ED7XYDpDM9Ab4C+w935HmWpAtaTMX/1W6f6nA8PAYyw=="
         },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
         "test-coverage": "vitest run --coverage"
     },
     "dependencies": {
-        "@bcgov-nr/nr-theme": "^1.8.3",
+        "@bcgov-nr/nr-theme": "^1.8.4",
         "@carbon/icons-vue": "^10.72.1",
         "aws-amplify": "^5.3.6",
         "axios": "1.6.5",

--- a/frontend/src/assets/styles/default-theme.scss
+++ b/frontend/src/assets/styles/default-theme.scss
@@ -20,7 +20,6 @@ $dark-text-primary: map.get(darkTheme.$dark-theme, 'text-primary');
 $light-layer-selected-01: map.get(lightTheme.$light-theme, 'layer-selected-01');
 $light-link-primary: map.get(lightTheme.$light-theme, 'link-primary');
 $light-link-primary-hover: map.get(lightTheme.$light-theme, 'link-primary-hover');
-$light-focus: map.get(lightTheme.$light-theme, 'focus');
 
 //border
 $light-border-interactive: map.get(

--- a/frontend/src/assets/styles/default-theme.scss
+++ b/frontend/src/assets/styles/default-theme.scss
@@ -20,6 +20,7 @@ $dark-text-primary: map.get(darkTheme.$dark-theme, 'text-primary');
 $light-layer-selected-01: map.get(lightTheme.$light-theme, 'layer-selected-01');
 $light-link-primary: map.get(lightTheme.$light-theme, 'link-primary');
 $light-link-primary-hover: map.get(lightTheme.$light-theme, 'link-primary-hover');
+$light-focus: map.get(lightTheme.$light-theme, 'focus');
 
 //border
 $light-border-interactive: map.get(

--- a/frontend/src/components/common/PageTitle.vue
+++ b/frontend/src/components/common/PageTitle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router';
+import { RouterLink, useRoute } from 'vue-router';
 import Breadcrumb from 'primevue/breadcrumb';
 import { breadcrumbState } from '@/store/BreadcrumbState';
 
@@ -18,7 +18,23 @@ const route = useRoute();
 </script>
 
 <template>
-    <Breadcrumb v-if="route.meta.hasBreadcrumb" :model="breadcrumbState" />
+    <Breadcrumb
+        v-if="route.meta.hasBreadcrumb"
+        :model="breadcrumbState"
+        :pt="{
+            menuitem: { class: 'custom-menuitem' },
+        }"
+    >
+        <template #item="{ item }">
+            <RouterLink
+                v-if="item.path"
+                :to="item.path"
+                class="custom-menuitem-link"
+            >
+                <span class="custom-menutitem-text">{{ item.label }}</span>
+            </RouterLink>
+        </template>
+    </Breadcrumb>
     <h1 class="title">{{ props.title }}</h1>
     <h2 class="subtitle">{{ props.subtitle }}</h2>
 </template>
@@ -37,5 +53,36 @@ const route = useRoute();
     line-height: 1.125rem;
     letter-spacing: 0.01rem;
     color: $light-text-secondary;
+}
+
+.custom-menuitem:focus-visible,
+.custom-menuitem-link:focus-visible {
+    outline: none;
+}
+
+.custom-menuitem-link {
+    padding: 0.2rem;
+    text-decoration: none;
+}
+
+.custom-menuitem-link:focus {
+    box-shadow: inset 0 0px 0px 0.063rem $light-focus;
+}
+
+.custom-menuitem:last-child .custom-menuitem-link {
+    pointer-events: none;
+}
+
+.custom-menutitem-text {
+    color: $light-link-primary;
+}
+
+.custom-menutitem-text:hover {
+    color: $light-link-primary-hover;
+}
+
+.custom-menuitem:last-child .custom-menutitem-text {
+    color: $light-text-primary;
+    display: contents;
 }
 </style>

--- a/frontend/src/components/common/PageTitle.vue
+++ b/frontend/src/components/common/PageTitle.vue
@@ -21,17 +21,15 @@ const route = useRoute();
     <Breadcrumb
         v-if="route.meta.hasBreadcrumb"
         :model="breadcrumbState"
-        :pt="{
-            menuitem: { class: 'custom-menuitem' },
-        }"
     >
         <template #item="{ item }">
             <RouterLink
                 v-if="item.path"
                 :to="item.path"
-                class="custom-menuitem-link"
             >
-                <span class="custom-menutitem-text">{{ item.label }}</span>
+                <span>
+                    {{ item.label }}
+                </span>
             </RouterLink>
         </template>
     </Breadcrumb>
@@ -53,36 +51,5 @@ const route = useRoute();
     line-height: 1.125rem;
     letter-spacing: 0.01rem;
     color: $light-text-secondary;
-}
-
-.custom-menuitem:focus-visible,
-.custom-menuitem-link:focus-visible {
-    outline: none;
-}
-
-.custom-menuitem-link {
-    padding: 0.2rem;
-    text-decoration: none;
-}
-
-.custom-menuitem-link:focus {
-    box-shadow: inset 0 0px 0px 0.063rem $light-focus;
-}
-
-.custom-menuitem:last-child .custom-menuitem-link {
-    pointer-events: none;
-}
-
-.custom-menutitem-text {
-    color: $light-link-primary;
-}
-
-.custom-menutitem-text:hover {
-    color: $light-link-primary-hover;
-}
-
-.custom-menuitem:last-child .custom-menutitem-text {
-    color: $light-text-primary;
-    display: contents;
 }
 </style>


### PR DESCRIPTION
- Fixed breadcrumb component not routing.

The breadcrumb component now receives the home as a prop, in the primevue breadcrumb component documentation has exemples using the name "`route`" for the the path but the component it self expects "`item.url`". Tried using "`route`" and "`path`" as the `routeItems` object key but it did not work, "`url`" worked though.

https://github.com/primefaces/primevue/commit/ad9b437003e0d3ae26047d2cfd1a6a6ecc9037d7#diff-33bf4bb142b615a34557b44002c2eb3ac4393bd3fa4099aede38fabbf4e5527f
https://primevue.org/breadcrumb/
