### PR TITLE
feat: #1150 navigation to grant delegated admin screen

### DIFF
--- a/frontend/src/components/grantaccess/GrantAccess.vue
+++ b/frontend/src/components/grantaccess/GrantAccess.vue
@@ -146,7 +146,7 @@ const handleSubmit = async () => {
         errorCode,
         role
     );
-    setCurrentTabState(TabKey.User);
+    setCurrentTabState(TabKey.UserAccess);
     router.push('/dashboard');
 };
 

--- a/frontend/src/components/grantaccess/GrantAccess.vue
+++ b/frontend/src/components/grantaccess/GrantAccess.vue
@@ -21,6 +21,8 @@ import UserNameInput from '@/components/grantaccess/form/UserNameInput.vue';
 import ForestClientInput from '@/components/grantaccess/form/ForestClientInput.vue';
 import FamLoginUserState from '@/store/FamLoginUserState';
 import type { FamRoleDto } from 'fam-admin-mgmt-api/model';
+import { setCurrentTabState } from '@/store/CurrentTabState';
+import { TabKey } from '@/enum/TabEnum';
 
 const defaultFormData = {
     domain: UserType.I,
@@ -144,7 +146,7 @@ const handleSubmit = async () => {
         errorCode,
         role
     );
-
+    setCurrentTabState(TabKey.User);
     router.push('/dashboard');
 };
 

--- a/frontend/src/components/grantaccess/GrantApplicationAdmin.vue
+++ b/frontend/src/components/grantaccess/GrantApplicationAdmin.vue
@@ -102,7 +102,7 @@ const handleSubmit = async () => {
             );
         }
     }
-    setCurrentTabState(TabKey.App);
+    setCurrentTabState(TabKey.AdminAccess);
     router.push('/dashboard');
 };
 </script>

--- a/frontend/src/components/grantaccess/GrantApplicationAdmin.vue
+++ b/frontend/src/components/grantaccess/GrantApplicationAdmin.vue
@@ -13,6 +13,8 @@ import { setNotificationMsg } from '@/store/NotificationState';
 import LoginUserState from '@/store/FamLoginUserState';
 import { computed, ref } from 'vue';
 import { UserType } from 'fam-app-acsctl-api/model';
+import { setCurrentTabState } from '@/store/CurrentTabState';
+import { TabKey } from '@/enum/TabEnum';
 
 const defaultFormData = {
     userId: '',
@@ -100,6 +102,7 @@ const handleSubmit = async () => {
             );
         }
     }
+    setCurrentTabState(TabKey.App);
     router.push('/dashboard');
 };
 </script>

--- a/frontend/src/components/grantaccess/GrantDelegatedAdmin.vue
+++ b/frontend/src/components/grantaccess/GrantDelegatedAdmin.vue
@@ -21,6 +21,8 @@ import type {
     FamRoleDto,
     FamAccessControlPrivilegeCreateRequest,
 } from 'fam-admin-mgmt-api/model';
+import { setCurrentTabState } from '@/store/CurrentTabState';
+import { TabKey } from '@/enum/TabEnum';
 
 const confirm = useConfirm();
 
@@ -140,8 +142,9 @@ const confirmSubmit = async () => {
         successList,
         errorList,
         errorCode,
-        role,
+        role
     );
+    setCurrentTabState(TabKey.Delegated);
     router.push('/dashboard');
 };
 

--- a/frontend/src/components/grantaccess/GrantDelegatedAdmin.vue
+++ b/frontend/src/components/grantaccess/GrantDelegatedAdmin.vue
@@ -144,7 +144,7 @@ const confirmSubmit = async () => {
         errorCode,
         role
     );
-    setCurrentTabState(TabKey.Delegated);
+    setCurrentTabState(TabKey.DelegatedAdminAccess);
     router.push('/dashboard');
 };
 

--- a/frontend/src/components/managePermissions/ManagePermissions.vue
+++ b/frontend/src/components/managePermissions/ManagePermissions.vue
@@ -82,12 +82,15 @@ const onApplicationSelected = async (e: DropdownChangeEvent) => {
     setSelectedApplication(e.value ? JSON.stringify(e.value) : null);
 
     if (e.value.id === FAM_APPLICATION_ID) {
+        setCurrentTabState(TabKey.AdminAccess);
         applicationAdmins.value = await fetchApplicationAdmins();
     } else {
+        if (!LoginUserState.isAdminOfSelectedApplication()) {
+            setCurrentTabState(TabKey.UserAccess);
+        }
         userRoleAssignments.value = await fetchUserRoleAssignments(
             selectedApplicationId.value
         );
-
         delegatedAdmins.value = await fetchDelegatedAdmins(
             selectedApplicationId.value
         );
@@ -201,7 +204,7 @@ const getCurrentTab = () => {
                 }"
             >
                 <TabPanel
-                    :key="TabKey.App"
+                    :key="TabKey.AdminAccess"
                     header="Application admins"
                     v-if="selectedApplicationId === FAM_APPLICATION_ID"
                 >
@@ -214,7 +217,7 @@ const getCurrentTab = () => {
                         @deleteAppAdmin="deleteAppAdmin"
                     />
                 </TabPanel>
-                <TabPanel :key="TabKey.User" header="Users" v-else>
+                <TabPanel :key="TabKey.UserAccess" header="Users" v-else>
                     <template #header>
                         <Icon icon="user" :size="IconSize.small" />
                     </template>
@@ -227,7 +230,7 @@ const getCurrentTab = () => {
                 </TabPanel>
 
                 <TabPanel
-                    :key="TabKey.Delegated"
+                    :key="TabKey.DelegatedAdminAccess"
                     v-if="
                         LoginUserState.isAdminOfSelectedApplication() &&
                         selectedApplicationId !== FAM_APPLICATION_ID

--- a/frontend/src/enum/TabEnum.ts
+++ b/frontend/src/enum/TabEnum.ts
@@ -1,0 +1,5 @@
+export enum TabKey {
+    App = 'app',
+    User = 'user',
+    Delegated = 'delegated'
+}

--- a/frontend/src/enum/TabEnum.ts
+++ b/frontend/src/enum/TabEnum.ts
@@ -1,5 +1,5 @@
 export enum TabKey {
-    App = 'app',
-    User = 'user',
-    Delegated = 'delegated'
+    AdminAccess = 'adminAccess',
+    UserAccess = 'userAccess',
+    DelegatedAdminAccess = 'delegatedAdminAccess'
 }

--- a/frontend/src/layouts/ProtectedLayout.vue
+++ b/frontend/src/layouts/ProtectedLayout.vue
@@ -27,6 +27,8 @@ const setSideNavOptions = () => {
 
         if (LoginUserState.isAdminOfSelectedApplication()) {
             disableSideNavOption('Add delegated admin', false);
+        } else {
+            disableSideNavOption('Add delegated admin', true);
         }
     }
 };
@@ -52,10 +54,7 @@ const disableSideNavOption = (optionName: string, disabled: boolean) => {
 };
 </script>
 <template>
-    <Header
-        title="FAM"
-        subtitle="Forests Access Management"
-    />
+    <Header title="FAM" subtitle="Forests Access Management" />
 
     <SideNav :data="navigationData" />
     <div class="main">

--- a/frontend/src/static/sideNav.json
+++ b/frontend/src/static/sideNav.json
@@ -23,7 +23,7 @@
             {
                 "name": "Add delegated admin",
                 "icon": "enterprise",
-                "link": "#",
+                "link": "/grant-delegated-admin",
                 "disabled": true
             }
         ]

--- a/frontend/src/store/CurrentTabState.ts
+++ b/frontend/src/store/CurrentTabState.ts
@@ -1,0 +1,11 @@
+import { ref } from 'vue';
+
+const currentTabState = ref<string>("");
+
+export const setCurrentTabState = (status: string) => {
+    currentTabState.value = status;
+}
+
+export const getCurrentTabState = (): string => {
+    return currentTabState.value;
+}


### PR DESCRIPTION
- sidebar item created for delegated admin page;
- navigation to grant delegated admin page from dashboard table button;
- show the delegated admin management functionality only if I'm an app admin (not including FAM admins);
- selecting correct tab in dashboard page after creating a delegated admin or granting a regular user access;