### PR TITLE
fix: #1232 add flyway script to add a new client role

### DIFF
--- a/server/flyway/sql/V39__add_client_role.sql
+++ b/server/flyway/sql/V39__add_client_role.sql
@@ -10,7 +10,7 @@ DELETE FROM app_fam.fam_role WHERE application_id IN (
     SELECT application_id FROM app_fam.fam_application WHERE application_name IN ('CLIENT_DEV', 'CLIENT_TEST', 'CLIENT_PROD')
 );
 
--- Add a role for CLIENT_DEV
+-- Add a role for CLIENT_DEV, CLIENT_TEST and CLIENT_PROD
 INSERT INTO app_fam.fam_role (
     role_name,
     role_purpose,
@@ -19,29 +19,7 @@ INSERT INTO app_fam.fam_role (
     create_user,
     create_date
 )
-VALUES ('CLIENT_EDITOR', 'Create and edit client information', (select application_id from app_fam.fam_application where application_name = 'CLIENT_DEV'), 'C', CURRENT_USER, CURRENT_DATE)
-;
-
--- Add a role for CLIENT_TEST
-INSERT INTO app_fam.fam_role (
-    role_name,
-    role_purpose,
-    application_id,
-    role_type_code,
-    create_user,
-    create_date
-)
-VALUES ('CLIENT_EDITOR', 'Create and edit client information', (select application_id from app_fam.fam_application where application_name = 'CLIENT_TEST'), 'C', CURRENT_USER, CURRENT_DATE)
-;
-
--- Add a role for CLIENT_PROD
-INSERT INTO app_fam.fam_role (
-    role_name,
-    role_purpose,
-    application_id,
-    role_type_code,
-    create_user,
-    create_date
-)
-VALUES ('CLIENT_EDITOR', 'Create and edit client information', (select application_id from app_fam.fam_application where application_name = 'CLIENT_PROD'), 'C', CURRENT_USER, CURRENT_DATE)
+VALUES ('CLIENT_EDITOR', 'Ministry role to approve/reject submissions, create client records, and perform non-administrative edits to client records', (select application_id from app_fam.fam_application where application_name = 'CLIENT_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('CLIENT_EDITOR', 'Ministry role to approve/reject submissions, create client records, and perform non-administrative edits to client records', (select application_id from app_fam.fam_application where application_name = 'CLIENT_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('CLIENT_EDITOR', 'Ministry role to approve/reject submissions, create client records, and perform non-administrative edits to client records', (select application_id from app_fam.fam_application where application_name = 'CLIENT_PROD'), 'C', CURRENT_USER, CURRENT_DATE)
 ;

--- a/server/flyway/sql/V39__add_client_role.sql
+++ b/server/flyway/sql/V39__add_client_role.sql
@@ -1,0 +1,47 @@
+-- Delete any role assignments to the CLIENT initial testing roles
+DELETE FROM app_fam.fam_user_role_xref WHERE role_id IN
+    (SELECT role_id from app_fam.fam_role WHERE application_id IN
+        (SELECT application_id FROM app_fam.fam_application WHERE application_name IN ('CLIENT_DEV', 'CLIENT_TEST', 'CLIENT_PROD'))
+    )
+;
+
+-- Delete previously created CLIENT testing roles for client_dev, client_test and client_prod applications
+DELETE FROM app_fam.fam_role WHERE application_id IN (
+    SELECT application_id FROM app_fam.fam_application WHERE application_name IN ('CLIENT_DEV', 'CLIENT_TEST', 'CLIENT_PROD')
+);
+
+-- Add a role for CLIENT_DEV
+INSERT INTO app_fam.fam_role (
+    role_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('CLIENT_EDITOR', 'Create and edit client information', (select application_id from app_fam.fam_application where application_name = 'CLIENT_DEV'), 'C', CURRENT_USER, CURRENT_DATE)
+;
+
+-- Add a role for CLIENT_TEST
+INSERT INTO app_fam.fam_role (
+    role_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('CLIENT_EDITOR', 'Create and edit client information', (select application_id from app_fam.fam_application where application_name = 'CLIENT_TEST'), 'C', CURRENT_USER, CURRENT_DATE)
+;
+
+-- Add a role for CLIENT_PROD
+INSERT INTO app_fam.fam_role (
+    role_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('CLIENT_EDITOR', 'Create and edit client information', (select application_id from app_fam.fam_application where application_name = 'CLIENT_PROD'), 'C', CURRENT_USER, CURRENT_DATE)
+;


### PR DESCRIPTION
refs: #1232

- Remove the old client roles (USER_READ, USER_WRITE) we created when onboarding them to FAM, we just created those two roles for them to play around, they are not in use
- Add a new role "CLIENT_EDITOR"

**Note:** this pr is for a **hotfix release** followed the [hotfix release strategy](https://github.com/bcgov/nr-forests-access-management/wiki/Creating-a-Release#hotfix-releases), so the fix branch [fix/1232-add-client-role](https://github.com/bcgov/nr-forests-access-management/tree/fix/1232-add-client-role) will be merged to a hotfix base branch (based on last release v1.12.0, and it has to be named "hotfix") to trigger release please management for hotfix release. The pr title starts with "fix", so the hotfix release tag will only bump a patch version, become **v1.12.1**, and won't conflict with our regular release v.1.13.0. Once we deploy the hotfix release in production, will create a new pr to merge the hotfix branch to main. 