### PR TITLE
fix: #1224 - Delegated Admin Table Disappears On Sign Out

### DIFF
--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -25,7 +25,7 @@ const login = async () => {
 };
 
 const logout = async () => {
-    Auth.signOut();
+    await Auth.signOut();
     LoginUserState.removeFamUser();
     console.log('User logged out.');
 };


### PR DESCRIPTION
- Fixed sign out bug by adding the missing "await" for the signOut promise, which was not blocking the code to wait for it's result, causing the cached data to be cleared before actually signing out.