### PR TITLE
fix: #1179 bceid login bug fix

### DIFF
--- a/frontend/src/router/routeHandlers.ts
+++ b/frontend/src/router/routeHandlers.ts
@@ -124,6 +124,19 @@ export const beforeEachRouteHandler = async (
         return { path: routeItems.landing.path };
     }
 
+    // if the login user does not have any access, return access error
+    if (
+        to.path !== '/' &&
+        LoginUserState.state.value.famLoginUser?.accesses?.length == 0
+    ) {
+        const routeError = new FamRouteError(
+            RouteErrorName.NOT_AUTHENTICATED_ERROR,
+            'You do not have any access in FAM',
+            { to, from }
+        );
+        emitRouteToastError(routeError);
+    }
+
     // Application selected guard.
     if (to.meta.requiresAppSelected && !isApplicationSelected.value) {
         const routeError = new FamRouteError(

--- a/infrastructure/server/outputs.tf
+++ b/infrastructure/server/outputs.tf
@@ -32,9 +32,7 @@ output "fam_cognito_domain" {
 
 output "frontend_logout_chain_url" {
   description = "Url of Siteminder and Keycloak logout chain for FAM frontend"
-  value = var.target_env == "prod" ? var.cognito_app_client_logout_chain_url.prod : (
-          var.target_env == "test" ? var.cognito_app_client_logout_chain_url.test :
-          var.cognito_app_client_logout_chain_url.dev)
+  value = var.target_env == "prod" ? var.cognito_app_client_logout_chain_url.prod : var.cognito_app_client_logout_chain_url.test
 }
 
 output "front_end_redirect_base_url" {

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -206,12 +206,6 @@ variable "cognito_app_client_logout_chain_url" {
 
 # Variables for FAM front-end config
 
-variable "frontend_logout_chain_url" {
-  description = "Url of Siteminder and Keycloak logout chain for frontend"
-  type = string
-  default = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
-}
-
 variable "front_end_redirect_path" {
   description = "Path to public FAM front-end (for redirect URI)"
   type = string

--- a/server/flyway/local_sql/sample_V1001__add_local_user_cognito_id.sql
+++ b/server/flyway/local_sql/sample_V1001__add_local_user_cognito_id.sql
@@ -45,5 +45,6 @@ VALUES
 ('JFERREIR','I','test-idir_278f48bd9mangledf7e618d@idir',CURRENT_USER),
 ('NSAGLION','I','test-idir_3f1414bd1mangled18a1293c40@idir',CURRENT_USER),
 ('CMENG','I','test-idir_a9888e8ac6a04mangled35df625bf@idir',CURRENT_USER),
-('OLIBERCH','I','test-idir_b7e191fa11dmangled9df1854b71@idir',CURRENT_USER);
+('OLIBERCH','I','test-idir_b7e191fa11dmangled9df1854b71@idir',CURRENT_USER),
+('LOAD-3-TEST', 'B', 'test-bceidbusiness_81069f39b35b4861bdmangled9dcd010582b63b112@bceidbusiness',CURRENT_USER);
 


### PR DESCRIPTION
refs: #1179 

Fix the bug found after deployment to dev:
- added to show a toast error message in the case the login user has no access in FAM
<img width="1262" alt="Screen Shot 2024-03-19 at 12 59 54 PM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/06c76712-26db-47f8-b51f-91a60a21b40c">

- fix the frontend redirect logout chain url config for environment variables 