### PR TITLE
feat: #1217 backend check both token and access control table for authorization

### DIFF
--- a/server/backend/api/app/crud/crud_access_control_privilege.py
+++ b/server/backend/api/app/crud/crud_access_control_privilege.py
@@ -1,0 +1,45 @@
+import logging
+
+from api.app.models.model import FamAccessControlPrivilege, FamRole
+from sqlalchemy.orm import Session
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_delegated_admin_by_user_and_app_id(
+    db: Session, user_id: int, app_id: int
+) -> FamAccessControlPrivilege:
+    """
+    Find out from `app_fam.fam_access_control_privilege` if user is the delegated admin of the application.
+
+    :param user_id: primary id that is associated with the user.
+    :param app_id: primary id that is associated with the application.
+    :return: FamAccessControlPrivilege record, role information the user is able to manage
+    """
+    return (
+        db.query(FamAccessControlPrivilege)
+        .join(FamRole)
+        .filter(
+            FamAccessControlPrivilege.user_id == user_id,
+            FamRole.application_id == app_id,
+        )
+        .one_or_none()
+    )
+
+
+def get_delegated_admin_by_user_id(
+    db: Session, user_id: int
+) -> FamAccessControlPrivilege:
+    """
+    Find out from `app_fam.fam_access_control_privilege` if user is the delegated admin of any application.
+
+    :param user_id: primary id that is associated with the user.
+    :return: FamAccessControlPrivilege record, role information the user is able to manage
+    """
+    return (
+        db.query(FamAccessControlPrivilege)
+        .filter(
+            FamAccessControlPrivilege.user_id == user_id,
+        )
+        .all()
+    )

--- a/server/backend/api/app/crud/crud_access_control_privilege.py
+++ b/server/backend/api/app/crud/crud_access_control_privilege.py
@@ -1,7 +1,9 @@
 import logging
+from typing import List
 
 from api.app.models.model import FamAccessControlPrivilege, FamRole
 from sqlalchemy.orm import Session
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,12 +31,12 @@ def get_delegated_admin_by_user_and_app_id(
 
 def get_delegated_admin_by_user_id(
     db: Session, user_id: int
-) -> FamAccessControlPrivilege:
+) -> List[FamAccessControlPrivilege]:
     """
     Find out from `app_fam.fam_access_control_privilege` if user is the delegated admin of any application.
 
     :param user_id: primary id that is associated with the user.
-    :return: FamAccessControlPrivilege record, role information the user is able to manage
+    :return: FamAccessControlPrivilege records, role information the user is able to manage
     """
     return (
         db.query(FamAccessControlPrivilege)

--- a/server/backend/api/app/crud/crud_access_control_privilege.py
+++ b/server/backend/api/app/crud/crud_access_control_privilege.py
@@ -7,13 +7,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_delegated_admin_by_user_and_app_id(
-    db: Session, user_id: int, app_id: int
+    db: Session, user_id: int, application_id: int
 ) -> FamAccessControlPrivilege:
     """
     Find out from `app_fam.fam_access_control_privilege` if user is the delegated admin of the application.
 
     :param user_id: primary id that is associated with the user.
-    :param app_id: primary id that is associated with the application.
+    :param application_id: primary id that is associated with the application.
     :return: FamAccessControlPrivilege record, role information the user is able to manage
     """
     return (
@@ -21,7 +21,7 @@ def get_delegated_admin_by_user_and_app_id(
         .join(FamRole)
         .filter(
             FamAccessControlPrivilege.user_id == user_id,
-            FamRole.application_id == app_id,
+            FamRole.application_id == application_id,
         )
         .one_or_none()
     )

--- a/server/backend/api/app/main.py
+++ b/server/backend/api/app/main.py
@@ -17,7 +17,7 @@ from .kms_lookup import init_bcsc_public_key
 from .routers import (router_application, router_bcsc_proxy,
                       router_forest_client, router_idim_proxy,
                       router_smoke_test,
-                      router_user_role_assignment)
+                      router_user_role_assignment, router_guards)
 
 logConfigFile = os.path.join(
     os.path.dirname(__file__),
@@ -104,11 +104,11 @@ app.include_router(router_user_role_assignment.router,
                    tags=["FAM User Role Assignment"])
 app.include_router(router_forest_client.router,
                    prefix=apiPrefix + '/forest_clients',
-                   dependencies=[Depends(jwt_validation.authorize)],
+                   dependencies=[Depends(router_guards.authorize)],
                    tags=["FAM Forest Clients"])
 app.include_router(router_idim_proxy.router,
                    prefix=apiPrefix + '/identity_search',
-                   dependencies=[Depends(jwt_validation.authorize)],
+                   dependencies=[Depends(router_guards.authorize)],
                    tags=["IDIR/BCeID Proxy"])
 
 # This router is used to proxy the BCSC userinfo endpoint

--- a/server/backend/api/app/routers/router_guards.py
+++ b/server/backend/api/app/routers/router_guards.py
@@ -76,7 +76,10 @@ def authorize(
     db: Session = Depends(database.get_db),
     requester: Requester = Depends(get_current_requester),
 ):
-    # we require user to be the app admin or delegated admin of at least one application
+    """
+    This authorize method is used by Forest Client API and IDIM Proxy API integration for a general authorization check,
+    we require user to be the app admin or delegated admin of at least one application
+    """
     if JWT_GROUPS_KEY not in claims or len(claims[JWT_GROUPS_KEY]) == 0:
         # if user has no application admin access
         # check if user has any delegated admin access
@@ -103,6 +106,10 @@ def authorize_by_app_id(
     claims: dict = Depends(validate_token),
     requester: Requester = Depends(get_current_requester),
 ):
+    """
+    This authorize_by_app_id method is used for the authorization check of a specific application,
+    we require user to be the app admin or delegated admin of the application
+    """
     application = crud_application.get_application(application_id=application_id, db=db)
     if not application:
         raise HTTPException(
@@ -177,8 +184,8 @@ def authorize_by_application_role(
     requester: Requester = Depends(get_current_requester),
 ):
     """
-    This router validation is currently design to validate logged on "admin"
-    has authority to perform actions for application with roles in [app]_ADMIN.
+    This router validation is currently design to validate logged on "admin/delegated admin"
+    has authority to perform actions for application with roles in [app]_ADMIN or has record in access_control_pirivilege table (for delegated admin).
     This function basically is the same and depends on (authorize_by_app_id()) but for
     the need that some routers contains target role_id in the request (instead of application_id).
     """

--- a/server/backend/api/app/routers/router_guards.py
+++ b/server/backend/api/app/routers/router_guards.py
@@ -78,13 +78,14 @@ def authorize(
 ):
     # we require user to be the app admin or delegated admin of at least one application
     if JWT_GROUPS_KEY not in claims or len(claims[JWT_GROUPS_KEY]) == 0:
-        # if use has no application admin access
+        # if user has no application admin access
         # check if user has any delegated admin access
         user_access_control_privilege = (
             crud_access_control_privilege.get_delegated_admin_by_user_id(
                 db, requester.user_id
             )
         )
+        # if user is not app admin and not delegated admin of any application, throw miss access group error
         if len(user_access_control_privilege) == 0:
             raise HTTPException(
                 status_code=403,
@@ -124,7 +125,7 @@ def authorize_by_app_id(
                 db, requester.user_id, application_id
             )
         )
-        # if user is not app admin and not delegated admin, throw permission error
+        # if user is not app admin and not delegated admin of the application, throw permission error
         if not user_access_control_privilege:
             raise HTTPException(
                 status_code=HTTPStatus.FORBIDDEN,

--- a/server/backend/api/app/routers/router_user_role_assignment.py
+++ b/server/backend/api/app/routers/router_user_role_assignment.py
@@ -30,7 +30,7 @@ def create_user_role_assignment(
     role_assignment_request: schemas.FamUserRoleAssignmentCreate,
     request: Request,
     db: Session = Depends(database.get_db),
-    token_claims: dict = Depends(jwt_validation.authorize),
+    token_claims: dict = Depends(jwt_validation.validate_token),
     requester: Requester = Depends(get_current_requester),
 ):
     """

--- a/server/backend/api/app/schemas.py
+++ b/server/backend/api/app/schemas.py
@@ -317,13 +317,12 @@ class Requester(BaseModel):
     user_name: Annotated[str, StringConstraints(max_length=20)]
     # "B"(BCeID) or "I"(IDIR). It is the IDP provider.
     user_type_code: Union[famConstants.UserType, None] = None
-    access_roles: Union[
-        List[Annotated[str, StringConstraints(max_length=50)]], None
-    ] = None
     user_guid: Optional[Annotated[str, StringConstraints(max_length=32)]] = None
+    user_id: int
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class TargetUser(Requester):
     pass
+

--- a/server/backend/testspg/authorization/test_authorization.py
+++ b/server/backend/testspg/authorization/test_authorization.py
@@ -1,40 +1,88 @@
 import logging
 import starlette.testclient
 from api.app.main import apiPrefix
-from testspg.jwt_utils import (create_jwt_token,
-                               create_jwt_claims,
-                               assert_error_response,
-                               headers)
-from api.app.jwt_validation import (ERROR_GROUPS_REQUIRED,
-                                    JWT_GROUPS_KEY)
+from sqlalchemy.orm import Session
+from testspg.jwt_utils import (
+    create_jwt_token,
+    create_jwt_claims,
+    assert_error_response,
+    headers,
+)
+from api.app.jwt_validation import (
+    ERROR_GROUPS_REQUIRED,
+    JWT_GROUPS_KEY,
+    ERROR_PERMISSION_REQUIRED,
+)
+from testspg.constants import TEST_FOM_DEV_APPLICATION_ID, CLIENT_NUMBER_EXISTS_ACTIVE
 
 LOGGER = logging.getLogger(__name__)
-fam_applications_endpoint = f"{apiPrefix}/fam_applications"
+
+# we don't have any delegated admin in the clean db, this test mainly focus on the token
+# the GET user role assignment endpoint requires requester to be the app admin or delegated admin of FOM DEV
+get_user_role_assignment_endpoint = (
+    f"{apiPrefix}/fam_applications/{TEST_FOM_DEV_APPLICATION_ID}/user_role_assignment"
+)
+# the search forest client number endpoint requires requester be the app admin or delegated admin of at least one app
+search_forest_client_endpoint = (
+    f"{apiPrefix}/forest_clients/search?client_number={CLIENT_NUMBER_EXISTS_ACTIVE}"
+)
 
 
-def test_get_application_missing_groups_failure(
-        test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+def test_get_user_role_assignment_miss_access_to_app_failure(
+    test_client_fixture: starlette.testclient.TestClient, test_rsa_key
+):
 
     claims = create_jwt_claims()
     claims.pop(JWT_GROUPS_KEY)
     token = create_jwt_token(test_rsa_key, roles=[], claims=claims)
 
-    response = test_client_fixture_unit.get(f"{fam_applications_endpoint}",
-                                            headers=headers(token))
+    response = test_client_fixture.get(
+        f"{get_user_role_assignment_endpoint}", headers=headers(token)
+    )
 
-    assert_error_response(response, 403, ERROR_GROUPS_REQUIRED)
+    assert_error_response(response, 403, ERROR_PERMISSION_REQUIRED)
 
 
-def test_get_application_no_groups_failure(
-        test_client_fixture_unit: starlette.testclient.TestClient,
-        test_rsa_key):
+def test_get_user_role_assignment_no_access_to_app_failure(
+    test_client_fixture: starlette.testclient.TestClient, test_rsa_key
+):
 
     claims = create_jwt_claims()
     claims[JWT_GROUPS_KEY] = []
     token = create_jwt_token(test_rsa_key, roles=[], claims=claims)
 
-    response = test_client_fixture_unit.get(f"{fam_applications_endpoint}",
-                                            headers=headers(token))
+    response = test_client_fixture.get(
+        f"{get_user_role_assignment_endpoint}", headers=headers(token)
+    )
+
+    assert_error_response(response, 403, ERROR_PERMISSION_REQUIRED)
+
+
+def test_search_forest_client_miss_access_failure(
+    test_client_fixture: starlette.testclient.TestClient, test_rsa_key
+):
+
+    claims = create_jwt_claims()
+    claims.pop(JWT_GROUPS_KEY)
+    token = create_jwt_token(test_rsa_key, roles=[], claims=claims)
+
+    response = test_client_fixture.get(
+        f"{search_forest_client_endpoint}", headers=headers(token)
+    )
+
+    assert_error_response(response, 403, ERROR_GROUPS_REQUIRED)
+
+
+def test_get_user_role_assignment_no_access_failure(
+    test_client_fixture: starlette.testclient.TestClient, test_rsa_key
+):
+
+    claims = create_jwt_claims()
+    claims[JWT_GROUPS_KEY] = []
+    token = create_jwt_token(test_rsa_key, roles=[], claims=claims)
+
+    response = test_client_fixture.get(
+        f"{search_forest_client_endpoint}", headers=headers(token)
+    )
 
     assert_error_response(response, 403, ERROR_GROUPS_REQUIRED)

--- a/server/backend/testspg/constants.py
+++ b/server/backend/testspg/constants.py
@@ -1,5 +1,6 @@
-
+import os
 from api.app import constants as fam_constants
+
 
 TEST_FOM_DEV_APPLICATION_ID = 2
 TEST_FOM_TEST_APPLICATION_ID = 3
@@ -13,6 +14,8 @@ TEST_NOT_EXIST_ROLE_ID = 0
 TEST_NOT_EXIST_APPLICATION_ID = 0
 
 TEST_CREATOR = "TESTER"
+
+TEST_USER_ID = 1
 
 # Testing Forest Client numbers (TEST Environment)
 CLIENT_NUMBER_LEN_TOO_SHORT = "0001011"
@@ -41,18 +44,18 @@ CLIENT_NUMBER_EXISTS_SUSPENDED = "00003643"
 TEST_USER_ROLE_ASSIGNMENT_FOM_DEV_CONCRETE = {
     "user_name": "fom_user_test",
     "user_type_code": "I",
-    "role_id": TEST_FOM_DEV_REVIEWER_ROLE_ID
+    "role_id": TEST_FOM_DEV_REVIEWER_ROLE_ID,
 }
 TEST_USER_ROLE_ASSIGNMENT_FOM_DEV_ABSTRACT = {
     "user_name": "fom_user_test",
     "user_type_code": fam_constants.UserType.BCEID,
     "role_id": TEST_FOM_DEV_SUBMITTER_ROLE_ID,
-    "forest_client_number": CLIENT_NUMBER_EXISTS_ACTIVE
+    "forest_client_number": CLIENT_NUMBER_EXISTS_ACTIVE,
 }
 TEST_USER_ROLE_ASSIGNMENT_FOM_TEST_CONCRETE = {
     "user_name": "fom_user_test",
     "user_type_code": "I",
-    "role_id": TEST_FOM_TEST_REVIEWER_ROLE_ID
+    "role_id": TEST_FOM_TEST_REVIEWER_ROLE_ID,
 }
 
 TEST_NEW_USER = {
@@ -60,4 +63,12 @@ TEST_NEW_USER = {
     "user_name": "TEST_USER",
     "create_user": TEST_CREATOR,
 }
-TEST_NOT_EXIST_USER_TYPE = 'NS'
+TEST_NOT_EXIST_USER_TYPE = "NS"
+
+TEST_IDIR_REQUESTER_DICT = {
+    "cognito_user_id": "test-idir_e72a12c916a44f39e5dcdffae7@idir",
+    "user_name": "IANLIU",
+    "user_type_code": fam_constants.UserType.IDIR,
+    "user_id": 4,
+    "user_guid": os.environ.get("TEST_IDIR_USER_GUID"),
+}

--- a/server/backend/testspg/crud/test_crud_access_control_privilege.py
+++ b/server/backend/testspg/crud/test_crud_access_control_privilege.py
@@ -1,0 +1,33 @@
+import logging
+
+from api.app.crud import crud_access_control_privilege
+from sqlalchemy.orm import Session
+from testspg.constants import (
+    TEST_FOM_DEV_APPLICATION_ID,
+    TEST_USER_ID,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_get_delegated_admin_by_user_and_app_id(db_pg_session: Session):
+    access_control_privileges = (
+        crud_access_control_privilege.get_delegated_admin_by_user_and_app_id(
+            db=db_pg_session,
+            user_id=TEST_USER_ID,
+            application_id=TEST_FOM_DEV_APPLICATION_ID,
+        )
+    )
+    # we don't have a any access control privilege for FOM by default
+    assert access_control_privileges is None
+
+
+def test_get_delegated_admin_by_user_id(db_pg_session: Session):
+    access_control_privileges = (
+        crud_access_control_privilege.get_delegated_admin_by_user_id(
+            db=db_pg_session,
+            user_id=TEST_USER_ID,
+        )
+    )
+    # we don't have a any access control privilege for any user by default
+    assert len(access_control_privileges) == 0

--- a/server/backend/testspg/crud/test_idim_proxy_service.py
+++ b/server/backend/testspg/crud/test_idim_proxy_service.py
@@ -1,11 +1,13 @@
 import copy
 import logging
 import os
-
+from requests import HTTPError
 import pytest
+
 from api.app.integration.idim_proxy import IdimProxyService
 from api.app.schemas import IdimProxySearchParam, Requester
-from requests import HTTPError
+from testspg.constants import TEST_IDIR_REQUESTER_DICT
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,15 +27,7 @@ class TestIdimProxyServiceClass(object):
 
     def setup_class(self):
         # local valid mock requester
-        self.requester = Requester(
-            **{
-                "cognito_user_id": "dev-idir_e72a12c916a44f39e5dcdffae7@idir",
-                "user_name": "IANLIU",
-                "user_type_code": "I",
-                "access_roles": ["FAM_ADMIN", "FOM_DEV_ADMIN"],
-                "user_guid": os.environ.get("TEST_IDIR_USER_GUID"),
-            }
-        )
+        self.requester = Requester(**TEST_IDIR_REQUESTER_DICT)
 
     def test_verify_init(self):
         idim_proxy_api = IdimProxyService(copy.deepcopy(self.requester))

--- a/server/backend/testspg/router/test_router_idim_proxy.py
+++ b/server/backend/testspg/router/test_router_idim_proxy.py
@@ -10,6 +10,7 @@ from api.app.routers.router_guards import get_current_requester, no_requester_ex
 from api.app.schemas import Requester
 from fastapi.testclient import TestClient
 from testspg.conftest import test_client_fixture
+from testspg.constants import TEST_IDIR_REQUESTER_DICT
 
 LOGGER = logging.getLogger(__name__)
 
@@ -18,29 +19,19 @@ endPoint_search_bceid = f"{apiPrefix}/identity_search/bceid"
 valid_user_id_param = "CMENG"
 valid_user_id_param_business_bceid = "LOAD-2-TEST"
 
-# Override this.
-# Valid sample IDIR type ("user_type": "I") requester
-sample_idir_requester_dict = {
-    "cognito_user_id": "dev-idir_e72a12c916a44f39e5dcdffae7@idir",
-    "user_name": "IANLIU",
-    "user_type_code": UserType.IDIR,
-    "access_roles": ["FAM_ADMIN", "FOM_DEV_ADMIN"],
-    "user_guid": os.environ.get("TEST_IDIR_USER_GUID"),
-}
-
 
 async def mock_get_current_requester_with_idir_user():
     """
     A mock for router dependency, for requester who is IDIR user.
     """
-    return Requester(**sample_idir_requester_dict)
+    return Requester(**TEST_IDIR_REQUESTER_DICT)
 
 
 async def mock_get_current_requester_with_none_idir_user():
     """
     A mock for router dependency, for requester who is not IDIR user.
     """
-    none_idir_requester = {**sample_idir_requester_dict}
+    none_idir_requester = {**TEST_IDIR_REQUESTER_DICT}
     none_idir_requester["user_type_code"] = UserType.BCEID  # Set to none-IDIR
     return Requester(**none_idir_requester)
 

--- a/server/flyway/sql/V43__api_db_user_read_delegated_admin_table.sql
+++ b/server/flyway/sql/V43__api_db_user_read_delegated_admin_table.sql
@@ -1,0 +1,3 @@
+-- Grant SELECT privilege to API db user to get delegated admin access
+GRANT SELECT ON app_fam.fam_access_control_privilege TO ${api_db_username}
+;


### PR DESCRIPTION
refs: #1217 

- Add read permission to backend api db user to the access_control_privilege table
- Update router guard method to check both token and access control table for general authorization, and authorization for specific application
- Update test