### PR TITLE
fix: #1266 update create_user and update_user length in db

### DIFF
--- a/server/admin_management/api/app/models/model.py
+++ b/server/admin_management/api/app/models/model.py
@@ -43,7 +43,7 @@ class FamApplication(Base):
         comment="Identifies which environment the application is for; DEV, TEST, PROD etc.",
     )
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -54,7 +54,7 @@ class FamApplication(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated "
         + "the record.",
     )
@@ -140,7 +140,7 @@ class FamApplicationAdmin(Base):
         + "FAM system.",
     )
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -151,7 +151,7 @@ class FamApplicationAdmin(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the "
         + "record. ",
     )
@@ -216,7 +216,7 @@ class FamAccessControlPrivilege(Base):
         comment="Unique ID to reference and identify the application role within FAM system.",
     )
     create_user = Column(
-        String(60), comment="The user or proxy account that created the record."
+        String(100), comment="The user or proxy account that created the record."
     )
     create_date = Column(
         TIMESTAMP(timezone=True, precision=6),
@@ -225,7 +225,7 @@ class FamAccessControlPrivilege(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(60),
+        String(100),
         comment="The user or proxy account that created or last updated the record.",
     )
     update_date = Column(
@@ -276,7 +276,7 @@ class FamForestClient(Base):
     # client_name = Column(String(100), nullable=True, index=True)  # noqa NOSONAR
 
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -287,7 +287,7 @@ class FamForestClient(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the record. ",
     )
     update_date = Column(
@@ -367,7 +367,7 @@ class FamUser(Base):
     )
     user_name = Column(String(100), nullable=False)
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -381,7 +381,7 @@ class FamUser(Base):
     business_guid = Column(String(32))
     cognito_user_id = Column(String(100))
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the record.",
     )
     update_date = Column(
@@ -453,7 +453,7 @@ class FamApplicationClient(Base):
     )
     cognito_client_id = Column(String(32), nullable=False)
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -469,7 +469,7 @@ class FamApplicationClient(Base):
         + "of an Application registered under FAM",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the "
         + "record. ",
     )
@@ -561,7 +561,7 @@ class FamRole(Base):
         comment="Sequentially assigned number to identify a ministry client.",
     )
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -579,7 +579,7 @@ class FamRole(Base):
         + "of a Role within the FAM Application",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the record. ",
     )
     update_date = Column(

--- a/server/backend/api/app/models/model.py
+++ b/server/backend/api/app/models/model.py
@@ -43,7 +43,7 @@ class FamApplication(Base):
         comment="Identifies which environment the application is for; DEV, TEST, PROD etc.",
     )
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -54,7 +54,7 @@ class FamApplication(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated "
         + "the record.",
     )
@@ -125,7 +125,7 @@ class FamForestClient(Base):
     # client_name = Column(String(100), nullable=True, index=True)  # noqa NOSONAR
 
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -136,7 +136,7 @@ class FamForestClient(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the record. ",
     )
     update_date = Column(
@@ -216,7 +216,7 @@ class FamUser(Base):
     )
     user_name = Column(String(100), nullable=False)
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -230,7 +230,7 @@ class FamUser(Base):
     business_guid = Column(String(32))
     cognito_user_id = Column(String(100))
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the " "record.",
     )
     update_date = Column(
@@ -301,7 +301,7 @@ class FamApplicationClient(Base):
     )
     cognito_client_id = Column(String(32), nullable=False)
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -317,7 +317,7 @@ class FamApplicationClient(Base):
         + "of an Application registered under FAM",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the "
         + "record. ",
     )
@@ -410,7 +410,7 @@ class FamRole(Base):
         comment="Sequentially assigned number to identify a ministry client.",
     )
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -428,7 +428,7 @@ class FamRole(Base):
         + "of a Role within the FAM Application",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated the record. ",
     )
     update_date = Column(
@@ -534,7 +534,7 @@ class FamUserRoleXref(Base):
         "of a Role within the FAM Application",
     )
     create_user = Column(
-        String(30),
+        String(100),
         nullable=False,
         comment="The user or proxy account that created the record.",
     )
@@ -545,7 +545,7 @@ class FamUserRoleXref(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(30),
+        String(100),
         comment="The user or proxy account that created or last updated "
         "the record. ",
     )
@@ -650,7 +650,7 @@ class FamAccessControlPrivilege(Base):
         comment="Unique ID to reference and identify the application role within FAM system.",
     )
     create_user = Column(
-        String(60), comment="The user or proxy account that created the record."
+        String(100), comment="The user or proxy account that created the record."
     )
     create_date = Column(
         TIMESTAMP(timezone=True, precision=6),
@@ -659,7 +659,7 @@ class FamAccessControlPrivilege(Base):
         comment="The date and time the record was created.",
     )
     update_user = Column(
-        String(60),
+        String(100),
         comment="The user or proxy account that created or last updated the record.",
     )
     update_date = Column(

--- a/server/flyway/sql/V45__create_and_update_user_length_increase.sql
+++ b/server/flyway/sql/V45__create_and_update_user_length_increase.sql
@@ -44,3 +44,6 @@ ALTER TABLE app_fam.fam_access_control_privilege
     ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
     ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
 
+ALTER TABLE app_fam.fam_application_admin
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);

--- a/server/flyway/sql/V45__create_and_update_user_length_increase.sql
+++ b/server/flyway/sql/V45__create_and_update_user_length_increase.sql
@@ -1,0 +1,46 @@
+-- Increase create_user and update_user to (100) because business bceid user's cognito_user_id is longer than 60 chars
+
+ALTER TABLE app_fam.fam_application
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_application_client
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_application_group_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_forest_client
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_group
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_group_role_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_role
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_user
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_user_group_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_user_role_xref
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+
+ALTER TABLE app_fam.fam_access_control_privilege
+    ALTER COLUMN create_user SET DATA TYPE VARCHAR(100),
+    ALTER COLUMN update_user SET DATA TYPE VARCHAR(100);
+


### PR DESCRIPTION
refs: #1266

Update create_user and update_user length in tables, so business bceid user's cognito_user_id can be inserted as create/update user

`fam_app_environment`, `fam_role_type` and `fam_user_type_code` has no create_user and update_user column
`fam_application_admin` no need to change, cause no bceid can grant application admin, but for consistency, updated it as well. 

![Image](https://github.com/bcgov/nr-forests-access-management/assets/23131735/f13160a3-6e8d-48d1-9466-db4a98a2a11a)

