### PR TITLE
fix: #1272 try to add username attribute for mapping

### DIFF
--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -272,7 +272,8 @@ variable "maximum_oidc_attribute_read_list" {
     "profile",
     "updated_at",
     "website",
-    "zoneinfo"
+    "zoneinfo",
+    "username"
   ]
 
 }
@@ -305,7 +306,9 @@ variable "maximum_oidc_attribute_write_list" {
     "profile",
     "updated_at",
     "website",
-    "zoneinfo"]
+    "zoneinfo",
+    "username"
+  ]
 }
 
 # Variables for connecting Cognito to BCSC OIDC


### PR DESCRIPTION
refs: #1272

One of my guess of the bcsc login error, is because of this "Attribute read and write permissions" mapping, it doesn't have the username in it. So if Cognito wants to do something with the username field but has no permission to do so, it might throw the error we got?  But I can't manually add it through the UI, so I wonder if I could just update the terraform to include it and deploy to DEV. The "maximum_oidc_attribute_read_list" and "maximum_oidc_attribute_write_list" are only used by forest client app integration, so it won't impact other apps. I also found out how to configure our AWS DEV cognito, so we can use AWS DEV to verify the bcsc login, no need to deploy to AWS TEST and PROD.

If it doesn't work I'll revert the code back. Again, forest-client-test and forest-client-prod has exact same read/write attribute permission, I don't know why TEST-BCSC login with forest-client-test works fine, but PROD-BCSC login with forest-client-prod doesn't work. This pr is just my guess. 

<img width="1473" alt="Screen Shot 2024-04-02 at 3 02 36 PM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/3af215f4-d39d-459b-ab14-f4ab371404c4">


