### PR TITLE
fix: #1272 revert read write attribute

### DIFF
--- a/infrastructure/server/oidc_idp_bcsc.tf
+++ b/infrastructure/server/oidc_idp_bcsc.tf
@@ -24,7 +24,6 @@ resource "aws_cognito_identity_provider" "dev_bcsc_oidc_provider" {
   }
 
   attribute_mapping = {
-    username = "sub",
     given_name = "given_name",
     family_name = "family_name",
     birthdate = "birthdate",
@@ -59,7 +58,6 @@ resource "aws_cognito_identity_provider" "test_bcsc_oidc_provider" {
   }
 
   attribute_mapping = {
-    username = "sub",
     given_name = "given_name",
     family_name = "family_name",
     birthdate = "birthdate",
@@ -95,7 +93,6 @@ resource "aws_cognito_identity_provider" "prod_bcsc_oidc_provider" {
   }
 
   attribute_mapping = {
-    username = "sub",
     given_name = "given_name",
     family_name = "family_name",
     birthdate = "birthdate",

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -272,7 +272,8 @@ variable "maximum_oidc_attribute_read_list" {
     "profile",
     "updated_at",
     "website",
-    "zoneinfo"
+    "zoneinfo",
+    "username"
   ]
 
 }
@@ -305,7 +306,9 @@ variable "maximum_oidc_attribute_write_list" {
     "profile",
     "updated_at",
     "website",
-    "zoneinfo"]
+    "zoneinfo",
+    "username"
+  ]
 }
 
 # Variables for connecting Cognito to BCSC OIDC

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -272,8 +272,7 @@ variable "maximum_oidc_attribute_read_list" {
     "profile",
     "updated_at",
     "website",
-    "zoneinfo",
-    "username"
+    "zoneinfo"
   ]
 
 }
@@ -306,8 +305,7 @@ variable "maximum_oidc_attribute_write_list" {
     "profile",
     "updated_at",
     "website",
-    "zoneinfo",
-    "username"
+    "zoneinfo"
   ]
 }
 


### PR DESCRIPTION
refs: #1272 

Got a pipeline error, seems like "username" is not a valid read/write attribute, revert the code back
<img width="1233" alt="Screen Shot 2024-04-03 at 10 08 49 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/c32ef5be-1013-495a-9b11-ee7336d22ff2">


Have another guess, noticed that for bceid user in Cognito, their user attributes have a `sub` field, and it is required, but for the test bcsc user, I didn't see a `sub` field in the user attributes. 
<img width="919" alt="Screen Shot 2024-04-03 at 10 24 35 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/aa2c537f-b2e2-410a-b323-c4a3fc28d0d1">
<img width="240" alt="Screen Shot 2024-04-03 at 10 24 40 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/81e9260e-fb00-4ada-88c6-eb4f17308345">

<img width="850" alt="Screen Shot 2024-04-03 at 10 25 57 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/059c0a3d-43cb-4618-816a-d82852797e35">

And checked our IDP config terraform file, for IDIR and BCEID, we didn't do a username mapping to sub, think Cognito will auto map it, so want to try to remove the username mapping to sub from the BCSC IDP config as well, and see if that brings any difference. 
<img width="904" alt="Screen Shot 2024-04-03 at 10 26 43 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/e7f5fbe8-b9c4-4e90-9e75-a51b20f9e1b8">
