### PR TITLE
fix: #1264 disable bceid login button

### DIFF
--- a/frontend/src/components/Landing.vue
+++ b/frontend/src/components/Landing.vue
@@ -30,6 +30,7 @@ import TreeLogs from '@/assets/images/tree-logs.jpg';
                 <Button
                     class="landing-button"
                     outlined
+                    disabled
                     label="Login with BCeID"
                     id="login-bceid-button"
                     @click="AuthService.loginBceid()"

--- a/frontend/src/tests/Landing.spec.ts
+++ b/frontend/src/tests/Landing.spec.ts
@@ -61,7 +61,7 @@ describe('Landing', () => {
         await button.trigger('click');
         expect(loginSpy).toHaveBeenCalled();
     });
-    it('should render BCeID button and be enabled', async () => {
+    it.skip('should render BCeID button and be enabled', async () => {
         const button = wrapper.get('#login-bceid-button');
         expect(button.classes()).toEqual(
             expect.arrayContaining(['landing-button'])
@@ -69,7 +69,7 @@ describe('Landing', () => {
         expect(button.html().includes('Login with BCeID')).toBe(true);
         expect(button.attributes()).not.toHaveProperty('disabled');
     });
-    it('should button Login with BCEID be clicked', async () => {
+    it.skip('should button Login with BCEID be clicked', async () => {
         const button = wrapper.get('#login-bceid-button');
         const loginSpy = vi.spyOn(AuthService, 'loginBceid');
         await button.trigger('click');


### PR DESCRIPTION
refs: #1264

- disabled the bceid login button
- skip the bceid login button test

This is only for the prod deployment to hide this functionality