### PR TITLE
fix: fix the table header text for delegated admin

### DIFF
--- a/frontend/src/components/managePermissions/table/DataTableHeader.vue
+++ b/frontend/src/components/managePermissions/table/DataTableHeader.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import InputText from 'primevue/inputtext';
 import router from '@/router';
+import { routeItems } from '@/router/routeItem';
 import { IconSize } from '@/enum/IconEnum';
 import { selectedApplicationDisplayText } from '@/store/ApplicationState';
 
@@ -12,33 +13,37 @@ const props = defineProps({
     },
     btnRoute: {
         type: String,
-        required: true
+        required: true,
     },
     filter: {
         type: String,
-        required: true
-    }
+        required: true,
+    },
 });
 const emit = defineEmits(['change']);
 
 const computedFilter = computed({
     get() {
-        return props.filter
+        return props.filter;
     },
     set(newValue) {
-        emit('change', newValue)
-    }
-})
+        emit('change', newValue);
+    },
+});
 
+const userLevelText = computed(() => {
+    if (props.btnRoute == routeItems.grantDelegatedAdmin.path)
+        return 'delegate admins';
+    return 'users';
+});
 </script>
 
 <template>
     <div class="custom-data-table-header">
-        <h3>{{ selectedApplicationDisplayText }} users</h3>
+        <h3>{{ selectedApplicationDisplayText }} {{ userLevelText }}</h3>
         <span>
-            This table shows all the users in
-            {{ selectedApplicationDisplayText }} and their permissions
-            levels
+            This table shows all the {{ userLevelText }} in
+            {{ selectedApplicationDisplayText }} and their permissions levels
         </span>
     </div>
 

--- a/frontend/src/components/managePermissions/table/DataTableHeader.vue
+++ b/frontend/src/components/managePermissions/table/DataTableHeader.vue
@@ -33,7 +33,7 @@ const computedFilter = computed({
 
 const userLevelText = computed(() => {
     if (props.btnRoute == routeItems.grantDelegatedAdmin.path)
-        return 'delegate admins';
+        return 'delegated admins';
     return 'users';
 });
 </script>

--- a/frontend/src/components/managePermissions/table/DataTableHeader.vue
+++ b/frontend/src/components/managePermissions/table/DataTableHeader.vue
@@ -33,8 +33,14 @@ const computedFilter = computed({
 
 const userLevelText = computed(() => {
     if (props.btnRoute == routeItems.grantDelegatedAdmin.path)
-        return 'delegated admins';
+        return 'delegated administrators';
     return 'users';
+});
+
+const tableHeaderCustomText = computed(() => {
+    if (props.btnRoute == routeItems.grantDelegatedAdmin.path)
+        return 'and the roles they are allowed to manage for their users';
+    return 'and their permissions levels';
 });
 </script>
 
@@ -43,7 +49,7 @@ const userLevelText = computed(() => {
         <h3>{{ selectedApplicationDisplayText }} {{ userLevelText }}</h3>
         <span>
             This table shows all the {{ userLevelText }} in
-            {{ selectedApplicationDisplayText }} and their permissions levels
+            {{ selectedApplicationDisplayText }} {{ tableHeaderCustomText }}
         </span>
     </div>
 


### PR DESCRIPTION
fix the table header for delegated admin, we don't want to confuse user for this prod deployment

<img width="1449" alt="image" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/7635272f-1a35-48cf-bf23-58b02a2e6953">

<img width="861" alt="image" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/eee342ed-4e64-4f17-be21-f5e4751ec370">

