### PR TITLE
fix: bceid login for FOM production login issue

### DIFF
--- a/server/auth_function/lambda_function.py
+++ b/server/auth_function/lambda_function.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger()
 
 IDP_NAME_BCSC_DEV = "ca.bc.gov.flnr.fam.dev"
 IDP_NAME_BCSC_TEST = "ca.bc.gov.flnr.fam.test"
-IDP_NAME_BCSC_PROD = "ca.bc.gov.flnr.fam.prod"
+IDP_NAME_BCSC_PROD = "ca.bc.gov.flnr.fam"
 IDP_NAME_IDIR = "idir"
 IDP_NAME_BCEID_BUSINESS = "bceidbusiness"
 
@@ -91,9 +91,9 @@ def lambda_handler(event: event_type.Event, context: Any) -> event_type.Event:
             audit_event_log["requestingUser"]["idpUserName"] = event["request"][
                 "userAttributes"
             ]["custom:idp_username"]
-            audit_event_log["requestingUser"]["businessGuid"] = event["request"][
-                "userAttributes"
-            ]["custom:idp_business_id"]
+            # audit_event_log["requestingUser"]["businessGuid"] = event["request"][
+            #     "userAttributes"
+            # ]["custom:idp_business_id"]
         else:
             audit_event_log["requestingUser"]["idpDisplayName"] = event["request"][
                 "userAttributes"

--- a/server/auth_function/lambda_function.py
+++ b/server/auth_function/lambda_function.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger()
 
 IDP_NAME_BCSC_DEV = "ca.bc.gov.flnr.fam.dev"
 IDP_NAME_BCSC_TEST = "ca.bc.gov.flnr.fam.test"
-IDP_NAME_BCSC_PROD = "ca.bc.gov.flnr.fam"
+IDP_NAME_BCSC_PROD = "ca.bc.gov.flnr.fam.prod"
 IDP_NAME_IDIR = "idir"
 IDP_NAME_BCEID_BUSINESS = "bceidbusiness"
 


### PR DESCRIPTION
FOM reports a bceid login issue:
<img width="939" alt="Screen Shot 2024-04-09 at 9 41 46 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/26bfc933-751a-4d69-9229-5d57f55c73b3">

Checked the AWS PROD Cloudwatch Auth Lambda log, found an error for the audit log when try to get the business guid. So comment out the audit log for getting the business guid, we might could use `event["request"]["userAttributes"].get("custom:idp_business_id") `, but want to fix the login issue as soon as possible, will work on the audit log later. 


<img width="1439" alt="Screen Shot 2024-04-09 at 9 34 42 AM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/e698efba-a70f-49a4-9a4c-cf5162f2c496">

Tested with my prod business bceid account, and it works fine. So the error could happen when the login user doesn't have a business_guid somehow, we need more investigation on that. Cause we'll need the business_guid for checking organizations later, we expect the business bceid login user should have a business_guid

<img width="923" alt="image" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/ad13267e-1c02-4c4b-9389-d35081fc2b59">

