### PR TITLE
fix: #1315 fix application name error

### DIFF
--- a/server/admin_management/api/app/utils/utils.py
+++ b/server/admin_management/api/app/utils/utils.py
@@ -13,6 +13,4 @@ def remove_app_env_suffix(name: str):
     suffix_list = ["_DEV", "_TEST", "_PROD"]
     for suffix in suffix_list:
         if name.endswith(suffix):
-            name = name.rstrip(suffix)
-            break
-    return name
+            return name[: -len(suffix)]

--- a/server/admin_management/api/app/utils/utils.py
+++ b/server/admin_management/api/app/utils/utils.py
@@ -14,3 +14,4 @@ def remove_app_env_suffix(name: str):
     for suffix in suffix_list:
         if name.endswith(suffix):
             return name[: -len(suffix)]
+    return name


### PR DESCRIPTION
refs: #1315

It's still unclear to me why rstrip() doesn't work properly, but changed to another way seems work fine now. 
<img width="802" alt="Screen Shot 2024-04-17 at 4 14 32 PM" src="https://github.com/bcgov/nr-forests-access-management/assets/23131735/9a7af7ca-bd9b-4ebc-839f-2aa2222a5eeb">
