### PR TITLE
fix: adjusting sidenav list for better viewing

### DIFF
--- a/frontend/src/assets/styles/default-theme.scss
+++ b/frontend/src/assets/styles/default-theme.scss
@@ -19,6 +19,11 @@ $text-on-color: map.get(darkTheme.$dark-theme, 'text-on-color');
 
 //lightTheme
 $light-layer-selected-01: map.get(lightTheme.$light-theme, 'layer-selected-01');
+$light-layer-hover-01: map.get(lightTheme.$light-theme, 'layer-hover-01');
+$light-layer-selected-hover-01: map.get(
+    lightTheme.$light-theme,
+    'layer-selected-hover-01'
+);
 $light-link-primary: map.get(lightTheme.$light-theme, 'link-primary');
 $light-link-primary-hover: map.get(
     lightTheme.$light-theme,

--- a/frontend/src/components/common/SideNav.vue
+++ b/frontend/src/components/common/SideNav.vue
@@ -1,26 +1,21 @@
 <script setup lang="ts">
 import Sidebar from 'primevue/sidebar';
 import router from '@/router';
-import { IconSize } from '@/enum/IconEnum';
 import { sideNavState } from '@/store/SideNavState';
 import type { PropType } from 'vue';
 import type { RouteLocationRaw } from 'vue-router';
-
-export interface ISideNavData {
-    name: string;
-    items: [ISideNavItem];
-}
 
 export interface ISideNavItem {
     name: string;
     icon: string;
     link: RouteLocationRaw;
     disabled: boolean;
+    items?: [ISideNavItem];
 }
 
 const props = defineProps({
     data: {
-        type: Object as PropType<ISideNavData[]>,
+        type: Object as PropType<ISideNavItem[]>,
         required: true,
         default: '',
     },
@@ -30,30 +25,30 @@ const props = defineProps({
     <Sidebar v-model:visible="sideNavState.isVisible">
         <nav class="sidenav">
             <div class="content">
-                <ul>
-                    <div v-for="item in props.data">
-                        <li class="header">{{ item.name }}</li>
-                        <ul>
-                            <li
-                                v-for="child in item.items"
-                                class="child"
-                                :class="{
-                                    'sidenav-selected':
-                                        $router.currentRoute.value.path ==
-                                        child.link,
-                                    'sidenav-disabled': child.disabled,
-                                }"
-                                @click="router.push(child.link)"
-                            >
-                                <Icon
-                                    class="custom-carbon-icon--sidenav"
-                                    :icon="child.icon.toString()"
-                                    :size="IconSize.small"
-                                />
-                                {{ child.name }}
-                            </li>
-                        </ul>
-                    </div>
+                <ul v-for="item in props.data">
+                    <li
+                        class="header"
+                        :class="{
+                            'sidenav-selected':
+                                $router.currentRoute.value.path == item.link,
+                            'sidenav-disabled': item.disabled,
+                        }"
+                        @click="router.push(item.link)"
+                    >
+                        {{ item.name }}
+                    </li>
+                    <li
+                        class="child"
+                        v-for="child in item.items"
+                        :class="{
+                            'sidenav-selected':
+                                $router.currentRoute.value.path == child.link,
+                            'sidenav-disabled': child.disabled,
+                        }"
+                        @click="router.push(child.link)"
+                    >
+                        <span>{{ child.name }}</span>
+                    </li>
                 </ul>
             </div>
 
@@ -83,7 +78,7 @@ const props = defineProps({
 @import '@/assets/styles/styles.scss';
 .sidenav {
     position: fixed;
-    padding: 0.313rem 0rem;
+    padding: 2.25rem 0rem;
     width: 100%;
     height: calc(100vh - 3.125rem);
     left: 0rem;
@@ -101,16 +96,15 @@ const props = defineProps({
 
 .sidenav ul {
     padding: 0;
+    margin: 0;
     list-style-type: none;
-}
-
-.sidenav li.header {
-    font-weight: 400;
 }
 
 .sidenav li {
     @extend %helper-text-01;
     color: $light-text-secondary;
+    font-size: 1rem;
+    font-weight: 400;
     align-items: center;
     padding: 0.9375rem 1rem;
     i {
@@ -121,14 +115,16 @@ const props = defineProps({
     }
 }
 
-.sidenav li.child {
-    font-size: 1rem;
+.sidenav li.child > span {
+    margin-left: 1.5rem;
 }
 
-.sidenav li.child:hover {
+.sidenav li.child:hover,
+li.header:hover {
     background: $light-layer-selected-01;
     box-shadow: inset 0.188rem 0rem 0rem $light-border-interactive;
     color: $light-text-primary;
+    font-weight: 700;
     cursor: pointer;
 }
 
@@ -140,6 +136,7 @@ const props = defineProps({
     background: $light-layer-selected-01;
     box-shadow: inset 0.188rem 0rem 0rem $light-border-interactive;
     color: $light-text-primary !important;
+    font-weight: 700 !important;
     cursor: pointer;
 }
 

--- a/frontend/src/components/common/SideNav.vue
+++ b/frontend/src/components/common/SideNav.vue
@@ -125,8 +125,7 @@ const props = defineProps({
 
 .sidenav li.child:hover,
 li.header:hover {
-    background: $light-layer-selected-01;
-    box-shadow: inset 0.188rem 0rem 0rem $light-border-interactive;
+    background: $light-layer-hover-01;
     color: $light-text-primary;
     font-weight: 700;
     cursor: pointer;
@@ -144,11 +143,8 @@ li.header:hover {
     cursor: pointer;
 }
 
-.sidenav li a:hover,
-ul#nav li.active a {
-    color: $light-text-primary;
-    background: $light-layer-selected-01;
-    box-shadow: inset 0.188rem 0rem 0rem $light-border-interactive;
+.sidenav-selected:hover {
+    background: $light-layer-selected-hover-01 !important;
 }
 
 @media (min-width: 768px) {

--- a/frontend/src/components/common/SideNav.vue
+++ b/frontend/src/components/common/SideNav.vue
@@ -127,7 +127,6 @@ const props = defineProps({
 li.header:hover {
     background: $light-layer-hover-01;
     color: $light-text-primary;
-    font-weight: 700;
     cursor: pointer;
 }
 

--- a/frontend/src/components/common/SideNav.vue
+++ b/frontend/src/components/common/SideNav.vue
@@ -25,30 +25,34 @@ const props = defineProps({
     <Sidebar v-model:visible="sideNavState.isVisible">
         <nav class="sidenav">
             <div class="content">
-                <ul v-for="item in props.data">
-                    <li
-                        class="header"
-                        :class="{
-                            'sidenav-selected':
-                                $router.currentRoute.value.path == item.link,
-                            'sidenav-disabled': item.disabled,
-                        }"
-                        @click="router.push(item.link)"
-                    >
-                        {{ item.name }}
-                    </li>
-                    <li
-                        class="child"
-                        v-for="child in item.items"
-                        :class="{
-                            'sidenav-selected':
-                                $router.currentRoute.value.path == child.link,
-                            'sidenav-disabled': child.disabled,
-                        }"
-                        @click="router.push(child.link)"
-                    >
-                        <span>{{ child.name }}</span>
-                    </li>
+                <ul>
+                    <template v-for="item in props.data">
+                        <li
+                            class="header"
+                            :class="{
+                                'sidenav-selected':
+                                    $router.currentRoute.value.path ==
+                                    item.link,
+                                'sidenav-disabled': item.disabled,
+                            }"
+                            @click="router.push(item.link)"
+                        >
+                            {{ item.name }}
+                        </li>
+                        <li
+                            class="child"
+                            v-for="child in item.items"
+                            :class="{
+                                'sidenav-selected':
+                                    $router.currentRoute.value.path ==
+                                    child.link,
+                                'sidenav-disabled': child.disabled,
+                            }"
+                            @click="router.push(child.link)"
+                        >
+                            <span>{{ child.name }}</span>
+                        </li>
+                    </template>
                 </ul>
             </div>
 

--- a/frontend/src/static/sideNav.json
+++ b/frontend/src/static/sideNav.json
@@ -1,36 +1,30 @@
 [
     {
+        "name": "Manage permissions",
+        "link": "/dashboard",
+        "disabled": false,
         "items": [
             {
-                "name": "Manage permissions",
-                "icon": "group--access",
-                "link": "/dashboard",
-                "disabled": false
-            },
-            {
                 "name": "Add user permission",
-                "icon": "virtual-column--key",
                 "link": "/grant",
                 "disabled": true
             },
             {
                 "name": "Add application admin",
-                "icon": "enterprise",
                 "link": "/grant-app-admin",
                 "disabled": true
             },
             {
                 "name": "Add delegated admin",
-                "icon": "enterprise",
                 "link": "/grant-delegated-admin",
                 "disabled": true
-            },
-            {
-                "name": "My permissions",
-                "icon": "user--profile",
-                "link": "/my-permissions",
-                "disabled": false
             }
         ]
+    },
+    {
+        "name": "My permissions",
+        "link": "/my-permissions",
+        "disabled": false,
+        "items": []
     }
 ]


### PR DESCRIPTION
Adjusting the sidenav list appearance per request:

![Capture-fam-nav-bar2](https://github.com/bcgov/nr-forests-access-management/assets/117364634/b4839879-7693-46c4-8c14-b11dc7dd04f3)
