### PR TITLE
fix: #1421 Disable adding forest client, and hide delegated admin features

### DIFF
--- a/frontend/src/components/grantaccess/GrantAccess.vue
+++ b/frontend/src/components/grantaccess/GrantAccess.vue
@@ -219,6 +219,7 @@ function toRequestPayload(formData: any, forestClientNumber: string) {
                     title="Organization information"
                     subtitle="Associate one or more Client IDs to this user"
                     :divider="false"
+                    class="invalid"
                 >
                     The client API is down and this role cannot be assigned. We
                     are working on fixing the issue. Please try again tomorrow.

--- a/frontend/src/components/grantaccess/GrantAccess.vue
+++ b/frontend/src/components/grantaccess/GrantAccess.vue
@@ -220,7 +220,10 @@ function toRequestPayload(formData: any, forestClientNumber: string) {
                     subtitle="Associate one or more Client IDs to this user"
                     :divider="false"
                 >
-                    <ForestClientInput
+                    The client API is down and this role cannot be assigned. We
+                    are working on fixing the issue. Please try again tomorrow.
+                    Thank you!
+                    <!-- <ForestClientInput
                         :userId="formData.userId"
                         :roleId="formData.roleId"
                         @setVerifiedForestClients="setVerifiedForestClients"
@@ -228,7 +231,7 @@ function toRequestPayload(formData: any, forestClientNumber: string) {
                             removeVerifiedForestClients
                         "
                         @resetVerifiedForestClients="resetVerifiedForestClients"
-                    />
+                    /> -->
                 </StepContainer>
 
                 <div class="button-stack">

--- a/frontend/src/components/managePermissions/ManagePermissions.vue
+++ b/frontend/src/components/managePermissions/ManagePermissions.vue
@@ -235,7 +235,7 @@ const getCurrentTab = () => {
                     />
                 </TabPanel>
 
-                <TabPanel
+                <!-- <TabPanel
                     :key="TabKey.DelegatedAdminAccess"
                     v-if="
                         LoginUserState.isAdminOfSelectedApplication() &&
@@ -254,7 +254,7 @@ const getCurrentTab = () => {
                             deleteDelegatedAdminAssignment
                         "
                     />
-                </TabPanel>
+                </TabPanel> -->
             </TabView>
         </div>
     </div>

--- a/frontend/src/layouts/ProtectedLayout.vue
+++ b/frontend/src/layouts/ProtectedLayout.vue
@@ -8,7 +8,7 @@ import {
     isApplicationSelected,
     selectedApplicationId,
 } from '@/store/ApplicationState';
-import LoginUserState from '@/store/FamLoginUserState';
+// import LoginUserState from '@/store/FamLoginUserState';
 
 const navigationData = ref<[ISideNavItem]>(sideNavData as any);
 
@@ -17,16 +17,16 @@ const setSideNavOptions = () => {
     if (selectedApplicationId.value === FAM_APPLICATION_ID) {
         disableSideNavOption('Add user permission', true);
         disableSideNavOption('Add application admin', false);
-        disableSideNavOption('Add delegated admin', true);
+        // disableSideNavOption('Add delegated admin', true);
     } else {
         disableSideNavOption('Add application admin', true);
         disableSideNavOption('Add user permission', false);
 
-        if (LoginUserState.isAdminOfSelectedApplication()) {
-            disableSideNavOption('Add delegated admin', false);
-        } else {
-            disableSideNavOption('Add delegated admin', true);
-        }
+        // if (LoginUserState.isAdminOfSelectedApplication()) {
+        //     disableSideNavOption('Add delegated admin', false);
+        // } else {
+        //     disableSideNavOption('Add delegated admin', true);
+        // }
     }
 };
 


### PR DESCRIPTION
refs: #1421 

- Disable adding forest client number for abstract role
- Hide creating/managing delegated admin functionalities 

Please note: the tests will fail in the pipeline because Forest Client API is down