### PR TITLE
fix: #1420 Update CloudFront default ttl to minimize down time caused by caching issue

### DIFF
--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "web_distribution" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 3600
+    default_ttl            = 300
     max_ttl                = 86400
 
 


### PR DESCRIPTION
refs: #1420