### PR TITLE
fix: #1190 'enter' behaviour on grant access form

### DIFF
--- a/frontend/src/components/grantaccess/ForestClientCard.vue
+++ b/frontend/src/components/grantaccess/ForestClientCard.vue
@@ -16,7 +16,7 @@ const props = defineProps({
         <Card class="custom-card">
             <template #header>
                 <Icon icon="checkmark--filled" :size="IconSize.small" />
-                <p>Verified Client ID information</p>
+                <p>Verified Client Number information</p>
             </template>
             <template #content>
                 <div class="w-100">
@@ -45,19 +45,19 @@ const props = defineProps({
                             v-if="!props.forestClientData"
                             style="margin-top: 0.75rem"
                         >
-                            Please enter an active Forest Client ID
+                            Please enter an active Forest Client Number
                         </p>
 
                         <p
                             class="flex-grow-0 client-id-wrapper"
                             v-if="props.forestClientData"
                         >
-                            <label for="forest-client-id">
-                                Client ID:
+                            <label for="forest-client-number">
+                                Client Number:
                             </label>
                             <span
-                                id="forest-client-id"
-                                name="forest-client-id"
+                                id="forest-client-number"
+                                name="forest-client-number"
                             >
                                 {{ forestItem.forest_client_number }}
                             </span>
@@ -81,10 +81,7 @@ const props = defineProps({
                             class="org-status-wrapper"
                             v-if="props.forestClientData"
                         >
-                            <label
-                                for="forest-client-status"
-                                class="status"
-                            >
+                            <label for="forest-client-status" class="status">
                                 Organization status:
                             </label>
                             <Tag

--- a/frontend/src/components/grantaccess/GrantAccess.vue
+++ b/frontend/src/components/grantaccess/GrantAccess.vue
@@ -228,7 +228,6 @@ function toRequestPayload(formData: any, forestClientNumber: string) {
                 <StepContainer
                     v-if="isAbstractRoleSelected()"
                     title="Organization information"
-                    subtitle="Associate one or more Client IDs to this user"
                     :divider="false"
                 >
                     <ForestClientInput

--- a/frontend/src/components/grantaccess/GrantDelegatedAdmin.vue
+++ b/frontend/src/components/grantaccess/GrantDelegatedAdmin.vue
@@ -238,7 +238,6 @@ function handleSubmit() {
                 <StepContainer
                     v-if="isAbstractRoleSelected()"
                     title="Organization information"
-                    subtitle="Associate one or more Client IDs to this user"
                     :divider="false"
                 >
                     <ForestClientInput

--- a/frontend/src/components/grantaccess/form/ForestClientInput.vue
+++ b/frontend/src/components/grantaccess/form/ForestClientInput.vue
@@ -37,7 +37,7 @@ const verifyForestClientNumber = async (forestClientNumbers: string) => {
     for (const forestClientNumber of forestNumbers) {
         if (isForestClientNumberAdded(forestClientNumber)) {
             forestClientNumberVerifyErrors.value.push(
-                `Client ID ${forestClientNumber} has already been added.`
+                `Client Number ${forestClientNumber} has already been added.`
             );
 
             continue;
@@ -47,7 +47,7 @@ const verifyForestClientNumber = async (forestClientNumbers: string) => {
             .then((result) => {
                 if (!result.data[0]) {
                     forestClientNumberVerifyErrors.value.push(
-                        `Client ID ${forestClientNumber} is invalid and cannot be added.`
+                        `Client Number ${forestClientNumber} is invalid and cannot be added.`
                     );
                     return;
                 }
@@ -56,7 +56,7 @@ const verifyForestClientNumber = async (forestClientNumbers: string) => {
                     FamForestClientStatusType.A
                 ) {
                     forestClientNumberVerifyErrors.value.push(
-                        `Client ID ${forestClientNumber} is inactive and cannot be added.`
+                        `Client Number ${forestClientNumber} is inactive and cannot be added.`
                     );
                     return;
                 }
@@ -72,7 +72,7 @@ const verifyForestClientNumber = async (forestClientNumbers: string) => {
             })
             .catch(() => {
                 forestClientNumberVerifyErrors.value.push(
-                    `An error has occurred. Client ID ${forestClientNumber} could not be added.`
+                    `An error has occurred. Client Number ${forestClientNumber} could not be added.`
                 );
             });
     }
@@ -121,7 +121,9 @@ watch(
 
 <template>
     <div>
-        <label for="forestClientInput">User’s Client ID (8 digits) </label>
+        <label for="forestClientInput"
+            >Add one or more client numbers (8 digits)
+        </label>
         <Field
             :name="props.fieldId"
             v-slot="{ field, errorMessage }"
@@ -131,11 +133,11 @@ watch(
                 <div>
                     <InputText
                         id="forestClientInput"
-                        placeholder="Enter and verify the client ID"
+                        placeholder="Enter and verify the client number"
                         v-bind="field"
                         class="w-100 custom-height"
                         @input="cleanupForestClientNumberInput()"
-                        @keypress.enter="
+                        @keydown.enter.prevent="
                             field.value &&
                                 !errorMessage &&
                                 verifyForestClientNumber(
@@ -155,8 +157,8 @@ watch(
                             !errorMessage &&
                             forestClientNumberVerifyErrors.length === 0
                         "
-                        >Add and verify the Client IDs. Add multiple numbers by
-                        separating them with commas</small
+                        >Add and verify the Client Numbers. Add multiple numbers
+                        by separating them with commas</small
                     >
                     <ErrorMessage
                         class="invalid-feedback"
@@ -185,10 +187,7 @@ watch(
                         isLoading()
                     "
                 >
-                    <Icon
-                        icon="add"
-                        :size="IconSize.small"
-                    />
+                    <Icon icon="add" :size="IconSize.small" />
                 </Button>
             </div>
         </Field>

--- a/frontend/src/components/grantaccess/form/UserNameInput.vue
+++ b/frontend/src/components/grantaccess/form/UserNameInput.vue
@@ -112,6 +112,7 @@ watch(
                         maxlength="20"
                         v-bind="field"
                         :class="{ 'is-invalid': errorMessage }"
+                        @keydown.enter.prevent="verifyUserId()"
                     />
                     <small
                         id="userIdInput-helper"

--- a/frontend/src/components/managePermissions/table/DelegatedAdminTable.vue
+++ b/frontend/src/components/managePermissions/table/DelegatedAdminTable.vue
@@ -140,7 +140,7 @@ const deleteDelegatedAdmin = (
                 ></Column>
                 <Column
                     field="role.client_number.forest_client_number"
-                    header="Client ID"
+                    header="Client Number"
                     sortable
                 >
                 </Column>

--- a/frontend/src/components/managePermissions/table/UserDataTable.vue
+++ b/frontend/src/components/managePermissions/table/UserDataTable.vue
@@ -156,7 +156,7 @@ function deleteAssignment(assignment: FamApplicationUserRoleAssignmentGet) {
                      -->
                 <Column
                     field="role.client_number.forest_client_number"
-                    header="Client ID"
+                    header="Client Number"
                     sortable
                 ></Column>
                 <Column field="role.role_name" header="Role" sortable>

--- a/frontend/src/components/myPermissions/MyPermissionsTable.vue
+++ b/frontend/src/components/myPermissions/MyPermissionsTable.vue
@@ -42,7 +42,7 @@ const myPermissionsSearchChange = (newvalue: string) => {
     <div class="my-permissions-table-wrapper">
         <DataTableHeader
             :hasHeader="false"
-            input-placeholder="search by application, environment, client IDs, company name, role, status, and more"
+            input-placeholder="search by application, environment, client numbers, company name, role, status, and more"
             @change="myPermissionsSearchChange"
             :filter="myPermissiosFilters['global'].value"
         />
@@ -87,7 +87,7 @@ const myPermissionsSearchChange = (newvalue: string) => {
             ></Column>
             <Column
                 field="clientId"
-                header="Client ID"
+                header="Client Number"
                 sortable
             >
             </Column>

--- a/frontend/src/services/utils.ts
+++ b/frontend/src/services/utils.ts
@@ -40,7 +40,7 @@ export const formValidationSchema = (isAbstractRoleSelected: boolean) => {
                         .matches(
                             //string of eight digits separeted by commas and optional whitespace
                             /^\s*\d{8}(\s*,\s*\d{8})*\s*$/,
-                            'Please enter a Forest Client ID with 8 digits long'
+                            'Please enter a Forest Client Number with 8 digits long'
                         ),
             })
             .nullable(),

--- a/frontend/src/tests/ForestClientInput.spec.ts
+++ b/frontend/src/tests/ForestClientInput.spec.ts
@@ -74,12 +74,12 @@ describe('ForestClientInput', () => {
     });
 
     it('should render forest client number input field', () => {
-        expect(wrapper.html().includes('User’s Client ID (8 digits)')).toBe(
+        expect(wrapper.html().includes('Add one or more client numbers (8 digits)')).toBe(
             true
         );
         expect(wrapper.find('#forestClientInput').exists()).toBe(true);
         // no forest client card is displayed initially
-        expect(wrapper.html().includes('Verified Client ID information')).toBe(
+        expect(wrapper.html().includes('Verified Client Number information')).toBe(
             false
         );
         // Verify if the Add button is rendered and it is disabled
@@ -109,12 +109,12 @@ describe('ForestClientInput', () => {
         // the inner array indicates how many parameters it has
         expect(setVerifiedForestClients![0][0]).toEqual(TEST_SUCCESS_FOREST_CLIENT_NUMBER);
         // the forest client information card shows and verify the information
-        expect(wrapper.html().includes('Verified Client ID information')).toBe(
+        expect(wrapper.html().includes('Verified Client Number information')).toBe(
             true
         );
         expect(
             wrapper
-                .find('#forest-client-id')
+                .find('#forest-client-number')
                 .text()
                 .includes(TEST_SUCCESS_FOREST_CLIENT_NUMBER)
         ).toBe(true);
@@ -137,7 +137,7 @@ describe('ForestClientInput', () => {
 
         await wrapper.find("[aria-label='Add Client Numbers']").trigger('click');
         await flushPromises();
-        expect(wrapper.find('#forestClientInputValidationError').element.textContent).contain(`Client ID ${TEST_INVALID_FOREST_CLIENT_NUMBER} is invalid and cannot be added.`);
+        expect(wrapper.find('#forestClientInputValidationError').element.textContent).contain(`Client Number ${TEST_INVALID_FOREST_CLIENT_NUMBER} is invalid and cannot be added.`);
     });
 
     it('should raise error for inactive forest client number', async () => {
@@ -147,7 +147,7 @@ describe('ForestClientInput', () => {
         await wrapper.find("[aria-label='Add Client Numbers']").trigger('click');
         await flushPromises();
 
-        expect(wrapper.find('#forestClientInputValidationError').element.textContent).contain(`Client ID ${TEST_INACTIVE_FOREST_CLIENT_NUMBER} is inactive and cannot be added.`);
+        expect(wrapper.find('#forestClientInputValidationError').element.textContent).contain(`Client Number ${TEST_INACTIVE_FOREST_CLIENT_NUMBER} is inactive and cannot be added.`);
     });
 
     it('should raise error for duplicate user input', async () => {
@@ -159,7 +159,7 @@ describe('ForestClientInput', () => {
         await flushPromises();
 
         // Check if the forest client number has been added to the card
-        expect(wrapper.html().includes('Verified Client ID information')).toBe(true);
+        expect(wrapper.html().includes('Verified Client Number information')).toBe(true);
 
         // Try to add the same client number again
         await input.setValue(TEST_SUCCESS_FOREST_CLIENT_NUMBER);
@@ -168,7 +168,7 @@ describe('ForestClientInput', () => {
         await verifyButton.trigger('click');
         await flushPromises();
 
-        expect(wrapper.find('#forestClientInputValidationError').element.textContent).contain(`Client ID ${TEST_SUCCESS_FOREST_CLIENT_NUMBER} has already been added.`);
+        expect(wrapper.find('#forestClientInputValidationError').element.textContent).contain(`Client Number ${TEST_SUCCESS_FOREST_CLIENT_NUMBER} has already been added.`);
         // The input field should still display the duplicate input
         expect(inputField.value).toBe(TEST_SUCCESS_FOREST_CLIENT_NUMBER);
         // Expect the card to have just one entry
@@ -194,10 +194,10 @@ describe('ForestClientInput', () => {
         // The third entry in the forest client card should be equal to the third active input
         expect(setVerifiedForestClients![2][0]).toEqual(TEST_SUCCESS_FOREST_CLIENT_NUMBER_3);
         // the forest client information card shows and verify the information
-        expect(wrapper.html().includes('Verified Client ID information')).toBe(
+        expect(wrapper.html().includes('Verified Client Number information')).toBe(
             true
         );
-        const clientIdCardList = wrapper.findAll('#forest-client-id');
+        const clientIdCardList = wrapper.findAll('#forest-client-number');
         const clientNameCardList = wrapper.findAll('#forest-client-name');
         const clientStatusCardList = wrapper.findAll('#forest-client-status');
 
@@ -242,12 +242,12 @@ describe('ForestClientInput', () => {
         // The second entry in the forest client card should be equal to the second active input
         expect(setVerifiedForestClients![1][0]).toEqual(TEST_SUCCESS_FOREST_CLIENT_NUMBER_2);
         // the forest client information card shows and verify the information
-        expect(wrapper.html().includes('Verified Client ID information')).toBe(
+        expect(wrapper.html().includes('Verified Client Number information')).toBe(
             true
         );
         expect(
             wrapper
-                .find('#forest-client-id')
+                .find('#forest-client-number')
                 .text()
                 .includes(TEST_SUCCESS_FOREST_CLIENT_NUMBER)
         ).toBe(true);
@@ -264,7 +264,7 @@ describe('ForestClientInput', () => {
         expect(inputField.value).toContain(TEST_INACTIVE_FOREST_CLIENT_NUMBER);
         expect(inputField.value).toContain(TEST_INVALID_FOREST_CLIENT_NUMBER);
 
-        const clientIdCardList = wrapper.findAll('#forest-client-id');
+        const clientIdCardList = wrapper.findAll('#forest-client-number');
 
         expect(clientIdCardList).toHaveLength(2);
 
@@ -305,13 +305,13 @@ describe('ForestClientInput', () => {
         await wrapper.find("[aria-label='Add Client Numbers']").trigger('click');
         await flushPromises();
 
-        expect(wrapper.findAll('#forest-client-id')).toHaveLength(1);
+        expect(wrapper.findAll('#forest-client-number')).toHaveLength(1);
 
         const deleteButton = wrapper.find('#btn-trash-can');
         deleteButton.trigger('click');
         await flushPromises();
 
-        expect(wrapper.findAll('#forest-client-id')).toHaveLength(0);
+        expect(wrapper.findAll('#forest-client-number')).toHaveLength(0);
 
         // removeVerifiedForestClients has been called when delete is clicked
         expect(wrapper.emitted()).toHaveProperty('removeVerifiedForestClients');
@@ -340,7 +340,7 @@ describe('ForestClientInput', () => {
         await wrapper.find("[aria-label='Add Client Numbers']").trigger('click');
         await flushPromises();
 
-        const clientIdCardList = wrapper.findAll('#forest-client-id');
+        const clientIdCardList = wrapper.findAll('#forest-client-number');
         expect(clientIdCardList).toHaveLength(1);
 
         // Changing the userId prop should cleanUp Forest Client Card
@@ -349,7 +349,7 @@ describe('ForestClientInput', () => {
         expect(wrapper.emitted()).toHaveProperty('resetVerifiedForestClients');
 
         // The forest client card should be cleared
-        expect(wrapper.findAll('#forest-client-id')).toHaveLength(0);
+        expect(wrapper.findAll('#forest-client-number')).toHaveLength(0);
 
         await input.setValue(TEST_SUCCESS_FOREST_CLIENT_NUMBER_2);
         expect(inputField.value).toBe(TEST_SUCCESS_FOREST_CLIENT_NUMBER_2);
@@ -357,14 +357,14 @@ describe('ForestClientInput', () => {
         await wrapper.find("[aria-label='Add Client Numbers']").trigger('click');
         await flushPromises();
 
-        expect(wrapper.findAll('#forest-client-id')).toHaveLength(1);
+        expect(wrapper.findAll('#forest-client-number')).toHaveLength(1);
 
         // Changing the roleId prop should cleanUp Forest Client Card
         await wrapper.setProps({ roleId: 1 });
 
         expect(wrapper.emitted()).toHaveProperty('resetVerifiedForestClients');
 
-        expect(wrapper.findAll('#forest-client-id')).toHaveLength(0);
+        expect(wrapper.findAll('#forest-client-number')).toHaveLength(0);
 
     });
 


### PR DESCRIPTION
- Removed the subtitle for the Organization Information section, and replace where it says “user’s client id” with “add one or more client numbers”
- After enter username and hit 'enter', the username is verified instead of submitting the form
- Replaced all instances of "Client ID" with "Client number"
- Updated Tests