### PR TITLE
fix: #1383 Only check if user needs accept terms and conditions if is FAM user

### DIFF
--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -45,7 +45,15 @@ const handlePostLogin = async () => {
         // This is to update the FamLoginUser for FamLoginUser.accesses.
         // For now team decided to grab user's access only when user login and may change later.
         await LoginUserState.cacheUserAccess();
-        await LoginUserState.requiresAcceptTermsCondition() && showTermsForAcceptance()
+
+        if (
+            LoginUserState.state.value.famLoginUser?.accesses &&
+            LoginUserState.state.value.famLoginUser.accesses.length > 0
+        ) {
+            // only check if user needs accept terms and conditions if is a FAM user
+            (await LoginUserState.requiresAcceptTermsCondition()) &&
+                showTermsForAcceptance();
+        }
     } catch (error) {
         console.log('Not signed in');
         console.log('Authentication Error:', error);


### PR DESCRIPTION
refs: #1383

Our backend protects our endpoints that only FAM user (has at least one delegated admin or admin role in FAM) can call, otherwise will return an authorization error. So update frontend to only check if user needs accept terms and conditions if the login user is FAM user (has access in FAM).