### PR TITLE
fix: #1481 add new configuration for idim api token to support test/prod environments for FAM PROD

### DIFF
--- a/.github/workflows/ci_infrastructure.yml
+++ b/.github/workflows/ci_infrastructure.yml
@@ -49,6 +49,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   frontend-terraform-plan:
@@ -82,4 +83,5 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -32,6 +32,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   aws-dev-deployment-frontend:

--- a/.github/workflows/dev_destruction.yml
+++ b/.github/workflows/dev_destruction.yml
@@ -27,6 +27,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   # Commenting out the destroy because we want cloudfront domain to be persistent

--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -29,6 +29,8 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
+      idim_proxy_api_api_key_prod: "${{ secrets.IDIM_PROXY_API_API_KEY_PROD }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   aws-prod-deployment-frontend:

--- a/.github/workflows/prod_destruction.yml
+++ b/.github/workflows/prod_destruction.yml
@@ -28,6 +28,8 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
+      idim_proxy_api_api_key_prod: "${{ secrets.IDIM_PROXY_API_API_KEY_PROD }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   # Commenting out the destroy because we want cloudfront domain to be persistent

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -38,6 +38,10 @@ on:
         required: true
       idim_proxy_api_api_key:
         required: true
+      idim_proxy_api_api_key_test:
+        required: true
+      idim_proxy_api_api_key_prod:
+        required: false
       gc_notify_email_api_key:
         required: true
 
@@ -172,6 +176,8 @@ jobs:
           test_oidc_bcsc_idp_client_secret = "${{ secrets.test_oidc_bcsc_idp_client_secret }}"
           prod_oidc_bcsc_idp_client_secret = "${{ secrets.prod_oidc_bcsc_idp_client_secret }}"
           idim_proxy_api_api_key = "${{ secrets.idim_proxy_api_api_key }}"
+          idim_proxy_api_api_key_test = "${{ secrets.idim_proxy_api_api_key_test }}"
+          idim_proxy_api_api_key_prod = "${{ secrets.idim_proxy_api_api_key_prod }}"
           gc_notify_email_api_key = "${{ secrets.gc_notify_email_api_key }}"
           EOF
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           FC_API_TOKEN: ${{ secrets.FOREST_CLIENT_API_API_KEY }}
           IDIM_PROXY_API_KEY: ${{ secrets.IDIM_PROXY_API_API_KEY }}
+          IDIM_PROXY_API_KEY_TEST: ${{ secrets.IDIM_PROXY_API_API_KEY }}
           GC_NOTIFY_EMAIL_API_KEY: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
           TEST_IDIR_USER_GUID: "${{ secrets.TEST_IDIR_USER_GUID }}"
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           FC_API_TOKEN: ${{ secrets.FOREST_CLIENT_API_API_KEY }}
           IDIM_PROXY_API_KEY: ${{ secrets.IDIM_PROXY_API_API_KEY }}
-          IDIM_PROXY_API_KEY_TEST: ${{ secrets.IDIM_PROXY_API_API_KEY }}
+          IDIM_PROXY_API_KEY_TEST: ${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}
           GC_NOTIFY_EMAIL_API_KEY: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
           TEST_IDIR_USER_GUID: "${{ secrets.TEST_IDIR_USER_GUID }}"
         run: |

--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -29,6 +29,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   aws-test-deployment-frontend:

--- a/.github/workflows/test_destruction.yml
+++ b/.github/workflows/test_destruction.yml
@@ -27,6 +27,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   # Commenting out the destroy because we want cloudfront domain to be persistent

--- a/.github/workflows/tools_deployment.yml
+++ b/.github/workflows/tools_deployment.yml
@@ -34,6 +34,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   aws-tools-deployment-frontend:

--- a/.github/workflows/tools_destruction.yml
+++ b/.github/workflows/tools_destruction.yml
@@ -27,6 +27,7 @@ jobs:
       test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
       idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      idim_proxy_api_api_key_test: "${{ secrets.IDIM_PROXY_API_API_KEY_TEST }}"
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
 
   # Commenting out the destroy because we want cloudfront domain to be persistent

--- a/infrastructure/server/fam_api.tf
+++ b/infrastructure/server/fam_api.tf
@@ -137,10 +137,14 @@ resource "aws_lambda_function" "fam-api-function" {
       FC_API_TOKEN = "${var.forest_client_api_api_key}"
       FC_API_BASE_URL = "${var.forest_client_api_base_url}"
       ENABLE_BCSC_JWKS_ENDPOINT = "True"
+
       IDIM_PROXY_BASE_URL = "${var.idim_proxy_api_base_url}"
       IDIM_PROXY_BASE_URL_TEST = "${var.idim_proxy_api_base_url_test}"
       IDIM_PROXY_BASE_URL_PROD = "${var.idim_proxy_api_base_url_prod}"
       IDIM_PROXY_API_KEY = "${var.idim_proxy_api_api_key}"
+      IDIM_PROXY_API_KEY_TEST = "${var.idim_proxy_api_api_key_test}"
+      IDIM_PROXY_API_KEY_PROD = "${var.idim_proxy_api_api_key_prod}"
+
       GC_NOTIFY_EMAIL_API_KEY = "${var.gc_notify_email_api_key}"
       TARGET_ENV = "${var.target_env}"
     }

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -201,6 +201,16 @@ variable "idim_proxy_api_api_key" {
   sensitive = true
 }
 
+variable "idim_proxy_api_api_key_test" {
+  type = string
+  sensitive = true
+}
+
+variable "idim_proxy_api_api_key_prod" {
+  type = string
+  sensitive = true
+}
+
 variable "gc_notify_email_api_key" {
   type = string
   sensitive = true

--- a/server/backend/api/app/integration/idim_proxy.py
+++ b/server/backend/api/app/integration/idim_proxy.py
@@ -22,7 +22,7 @@ class IdimProxyService:
 
     def __init__(self, requester: Requester, app_env: AppEnv = AppEnv.APP_ENV_TYPE_TEST):
         # TODO: get_idim_proxy_api_baseurl() already has swithcing logic based on app_env
-        # comment below by passing app_env to config; review again later.
+        # comment out below by passing app_env to config; review again later.
         # if app_env is None or app_env == AppEnv.APP_ENV_TYPE_DEV:
         #     self.api_instance_env = AppEnv.APP_ENV_TYPE_TEST
         # else:
@@ -34,7 +34,7 @@ class IdimProxyService:
         self.api_idim_proxy_url = (
             f"{config.get_idim_proxy_api_baseurl(app_env)}/api/idim-webservice"
         )
-        self.API_KEY = config.get_idim_proxy_api_key()
+        self.API_KEY = config.get_idim_proxy_api_key(app_env)
         self.headers = {"Accept": "application/json", "X-API-KEY": self.API_KEY}
 
         self.session = requests.Session()

--- a/server/backend/api/config/config.py
+++ b/server/backend/api/config/config.py
@@ -1,10 +1,9 @@
 import json
 import logging
 import os
+
 import boto3
-
 from api.app.constants import AppEnv
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -174,8 +173,16 @@ def get_idim_proxy_api_baseurl(app_env: AppEnv):
     return idim_proxy_api_baseurl
 
 
-def get_idim_proxy_api_key():
-    idim_proxy_api_key = get_env_var("IDIM_PROXY_API_KEY")
+def get_idim_proxy_api_key(app_env: AppEnv):
+    # idim_proxy_api_key = get_env_var("IDIM_PROXY_API_KEY")
+    idim_proxy_api_key = get_env_var("IDIM_PROXY_API_KEY_TEST")
+    LOGGER.info("Default to use key: IDIM_PROXY_API_KEY_TEST")
+    if (
+        app_env == AppEnv.APP_ENV_TYPE_PROD
+        and get_env_var("TARGET_ENV") == AppEnv.APP_ENV_TYPE_PROD
+    ):
+        idim_proxy_api_key = get_env_var("IDIM_PROXY_API_KEY_PROD")
+        LOGGER.info("Use key: IDIM_PROXY_API_KEY_PROD")
     return idim_proxy_api_key
 
 

--- a/server/backend/local-dev.env
+++ b/server/backend/local-dev.env
@@ -13,6 +13,7 @@ FC_API_TOKEN=thisisasecret
 IDIM_PROXY_BASE_URL_TEST=https://nr-fam-idim-lookup-proxy-test-backend.apps.silver.devops.gov.bc.ca
 IDIM_PROXY_BASE_URL_PROD=https://nr-fam-idim-lookup-proxy-prod-backend.apps.silver.devops.gov.bc.ca
 IDIM_PROXY_API_KEY=thisisasecret
+IDIM_PROXY_API_KEY_TEST=thisisasecret
 GC_NOTIFY_EMAIL_API_KEY=thisisasecret
 TEST_IDIR_USER_GUID=thisisasecret
 TARGET_ENV=TEST


### PR DESCRIPTION
ref #1481 
* Add "IDIM_PROXY_API_KEY_TEST" and "IDIM_PROXY_API_KEY_PROD" environment vars to support IDIM Proxy search on TEST and PROD.
* Add terraform configuration to setup the new two keys for fam_api.tf backend api.
* Add same switching logic at backend config.py file to obtain different API key based on app_env.
* TODO: need to setup Github secrets for DEV/TEST/PROD(2 new keys)