### PR TITLE
fix: #1481 Fix target env in backend to match app env with lower case

### DIFF
--- a/server/backend/api/config/config.py
+++ b/server/backend/api/config/config.py
@@ -166,7 +166,7 @@ def get_idim_proxy_api_baseurl(app_env: AppEnv):
     idim_proxy_api_baseurl = get_env_var("IDIM_PROXY_BASE_URL_TEST")
     if (
         app_env == AppEnv.APP_ENV_TYPE_PROD
-        and get_env_var("TARGET_ENV") == AppEnv.APP_ENV_TYPE_PROD
+        and get_env_var("TARGET_ENV") == AppEnv.APP_ENV_TYPE_PROD.lower()
     ):
         # only prod application integrated with FAM PROD can verify production users
         idim_proxy_api_baseurl = get_env_var("IDIM_PROXY_BASE_URL_PROD")

--- a/server/backend/local-dev.env
+++ b/server/backend/local-dev.env
@@ -15,4 +15,4 @@ IDIM_PROXY_BASE_URL_PROD=https://nr-fam-idim-lookup-proxy-prod-backend.apps.silv
 IDIM_PROXY_API_KEY=thisisasecret
 GC_NOTIFY_EMAIL_API_KEY=thisisasecret
 TEST_IDIR_USER_GUID=thisisasecret
-TARGET_ENV=TEST
+TARGET_ENV=test


### PR DESCRIPTION
 refs: #1481

Terraform config use lower case to set target_env variable, but the app env in our database is upper case. Need to match them with lower case. 