### PR TITLE
fix: Upgrade test container version to fix pipeline issue

### DIFF
--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -64,10 +64,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Auth function zip
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Tests and coverage
         env:
@@ -116,7 +116,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Tests and coverage
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Tests and coverage
         env:

--- a/server/admin_management/requirements-dev.txt
+++ b/server/admin_management/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest==7.2.0
-testcontainers==3.7.1
+testcontainers==4.7.2
 testcontainers-core==0.0.1rc1
 
 # used to create test JWT

--- a/server/auth_function/requirements-dev.txt
+++ b/server/auth_function/requirements-dev.txt
@@ -3,6 +3,6 @@ black==24.3.0
 flake8==7.0.0
 pytest-emoji==0.2.0
 pytest-md==0.2.0
-testcontainers==3.7.1
+testcontainers==4.7.2
 testcontainers-core==0.0.1rc1
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/server/backend/requirements-dev.txt
+++ b/server/backend/requirements-dev.txt
@@ -1,7 +1,7 @@
 flake8==7.0.0
 pytest==7.2.0
 pytest-mock==3.14.0
-testcontainers==3.7.1
+testcontainers==4.7.2
 testcontainers-core==0.0.1rc1
 
 # used to create the md report used by gha when tests run


### PR DESCRIPTION
Got a pipeline error when working on the pr #1515, all backend tests failed because of the test container cannot start the container from the docker compose file anymore. https://github.com/bcgov/nr-forests-access-management/actions/runs/10271029988/job/28426203492
<img width="1194" alt="Screen Shot 2024-08-06 at 3 15 05 PM" src="https://github.com/user-attachments/assets/95fffe8d-ed3a-4bf8-bc4d-95995fd98190">
<img width="1302" alt="Screen Shot 2024-08-06 at 3 14 38 PM" src="https://github.com/user-attachments/assets/caf36db6-8936-4dff-8e64-67b6933dc19b">
The cause of the issue is not very obvious. Everything works last week, and started to get this error from this morning. But could related to the way how test container starts the docker, the `docker-compose` command is no longer supported in GitHub Actions. I didn't find any documentation to explain the issue. But the issue could be solved by updating the `testcontainers` version to the latest v4.7.2, and that requires python > 3.9. 
<img width="1321" alt="Screen Shot 2024-08-06 at 3 07 57 PM" src="https://github.com/user-attachments/assets/8992e0fe-9b7c-4883-8757-2b9ea3802e3e">


So updated `testcontainers` version to v4.7.2 in backend, admin management and auth lambda folder, updated python to be v3.12 in pipeline workflow yamls.  
