### PR TITLE
fix: adjusted application name's max length to 100 for gc notify schema

### DIFF
--- a/server/backend/api/app/schemas.py
+++ b/server/backend/api/app/schemas.py
@@ -251,7 +251,7 @@ class IdimProxyBceidInfo(BaseModel):
 class GCNotifyGrantAccessEmailParam(BaseModel):
     first_name: Optional[Annotated[str, StringConstraints(max_length=50)]] = None
     last_name: Optional[Annotated[str, StringConstraints(max_length=50)]] = None
-    application_name: Annotated[str, StringConstraints(max_length=35)]
+    application_name: Annotated[str, StringConstraints(max_length=100)]
     role_list_string: Annotated[str, StringConstraints(max_length=500)]
     application_team_contact_email: Optional[EmailStr] = None
     send_to_email: EmailStr


### PR DESCRIPTION
Application name should have a max length of 100 instead of 35