### PR TITLE
fix: #1638 Fix updating forest client name error after search when forest client number isn't a valid one. 

### DIFF
--- a/server/backend/api/app/decorators/forest_client_dec.py
+++ b/server/backend/api/app/decorators/forest_client_dec.py
@@ -72,6 +72,6 @@ def __post_sync_forest_clients(result_list: List[FamApplicationUserRoleAssignmen
         for item in result_list:
             if item.role.forest_client:
                 fcn = item.role.forest_client.forest_client_number
-                item.role.forest_client.client_name = fc_search_client_name_dict[fcn]
+                item.role.forest_client.client_name = fc_search_client_name_dict.get(fcn)
 
     return result_list

--- a/server/backend/testspg/decorators/test_forest_client_dec.py
+++ b/server/backend/testspg/decorators/test_forest_client_dec.py
@@ -34,12 +34,16 @@ def dummy_fn_to_be_decorated(
             TestAppUserRoleResultDictKeys.NO_RESULT
         ),
         (   # fn return with no FC in items.
-            APP_USER_ROLE_GET_RESULTS_NO_PAGE_META[TestAppUserRoleResultDictKeys.NO_FC_RESULTS],
-            TestAppUserRoleResultDictKeys.NO_FC_RESULTS
+            APP_USER_ROLE_GET_RESULTS_NO_PAGE_META[TestAppUserRoleResultDictKeys.NO_FC_IN_RESULTS],
+            TestAppUserRoleResultDictKeys.NO_FC_IN_RESULTS
         ),
         (   # fn return with FC in items.
-            APP_USER_ROLE_GET_RESULTS_NO_PAGE_META[TestAppUserRoleResultDictKeys.WITH_FC_RESULTS],
-            TestAppUserRoleResultDictKeys.WITH_FC_RESULTS
+            APP_USER_ROLE_GET_RESULTS_NO_PAGE_META[TestAppUserRoleResultDictKeys.WITH_FC_IN_RESULTS],
+            TestAppUserRoleResultDictKeys.WITH_FC_IN_RESULTS
+        ),
+        (   # fn return with FC in items but FC does not exist in search (legacy or not active).
+            APP_USER_ROLE_GET_RESULTS_NO_PAGE_META[TestAppUserRoleResultDictKeys.WITH_FC_NOT_ACTIVE_RESULT],
+            TestAppUserRoleResultDictKeys.WITH_FC_NOT_ACTIVE_RESULT
         ),
     ],
 )
@@ -62,10 +66,13 @@ def test_should_update_client_name_for_forest_client_fn_results(
     # call decorated function
     fn_dec_return = dummy_fn_to_be_decorated(mock_fn_return)
 
-    if expected_results_condition is not TestAppUserRoleResultDictKeys.WITH_FC_RESULTS:
+    if expected_results_condition is not TestAppUserRoleResultDictKeys.WITH_FC_IN_RESULTS:
         # expect decorated results is the same and no forest client name update.
         assert fn_dec_return.results == APP_USER_ROLE_GET_RESULTS_NO_PAGE_META[expected_results_condition]
-        assert mock_fc_search.call_count == 0
+        if (expected_results_condition is TestAppUserRoleResultDictKeys.WITH_FC_NOT_ACTIVE_RESULT):
+            assert mock_fc_search.call_count == 1
+        else:
+            assert mock_fc_search.call_count == 0
 
     else:
         # expect decorated results contains client name update.

--- a/server/backend/testspg/test_data/forest_client_mock_data.py
+++ b/server/backend/testspg/test_data/forest_client_mock_data.py
@@ -17,8 +17,9 @@ from api.app.schemas.fam_user_type import FamUserTypeSchema
 
 class TestAppUserRoleResultDictKeys(str, Enum):
     NO_RESULT = "no_result"
-    NO_FC_RESULTS = "no_fc_results"
-    WITH_FC_RESULTS = "with_fc_results"
+    NO_FC_IN_RESULTS = "no_fc_results"
+    WITH_FC_IN_RESULTS = "with_fc_results",
+    WITH_FC_NOT_ACTIVE_RESULT = "with_fc_but_not_active_no_result"
 
 """
 Mock data for `get_application_role_assignments()` return in PagedResultsSchema.results.
@@ -26,7 +27,7 @@ Use 'TestAppUserRoleResultDictKeys' enum to identify different set of data.
 """
 APP_USER_ROLE_GET_RESULTS_NO_PAGE_META: dict[str, List[FamApplicationUserRoleAssignmentGetSchema]] = {
     TestAppUserRoleResultDictKeys.NO_RESULT: [],
-    TestAppUserRoleResultDictKeys.NO_FC_RESULTS: [
+    TestAppUserRoleResultDictKeys.NO_FC_IN_RESULTS: [
         FamApplicationUserRoleAssignmentGetSchema(user_role_xref_id=900, user_id=900, role_id=900,
             user=FamUserInfoSchema(user_name="tu_1", user_type_relation=FamUserTypeSchema(user_type_code=UserType.BCEID, description="dummy_desc")),
             role=FamRoleWithClientSchema(role_id=900, role_name="r1", role_type_code=RoleType.ROLE_TYPE_CONCRETE, role_purpose="Test dummy role",
@@ -45,7 +46,7 @@ APP_USER_ROLE_GET_RESULTS_NO_PAGE_META: dict[str, List[FamApplicationUserRoleAss
             ),
             create_date=datetime.datetime(2024, 11, 1, 19, 44, 47)),
     ],
-    TestAppUserRoleResultDictKeys.WITH_FC_RESULTS: [
+    TestAppUserRoleResultDictKeys.WITH_FC_IN_RESULTS: [
         FamApplicationUserRoleAssignmentGetSchema(user_role_xref_id=902, user_id=903, role_id=990,
             user=FamUserInfoSchema(user_name="tu_1", user_type_relation=FamUserTypeSchema(user_type_code=UserType.BCEID, description="dummy_desc")),
             role=FamRoleWithClientSchema(role_id=990, role_name="r2_00001011", role_type_code=RoleType.ROLE_TYPE_CONCRETE, role_purpose="Test dummy role",
@@ -75,5 +76,17 @@ APP_USER_ROLE_GET_RESULTS_NO_PAGE_META: dict[str, List[FamApplicationUserRoleAss
                 forest_client_relation=None
             ),
             create_date=datetime.datetime(2024, 11, 1, 19, 44, 47)) # no FC
+    ],
+    TestAppUserRoleResultDictKeys.WITH_FC_NOT_ACTIVE_RESULT: [
+       FamApplicationUserRoleAssignmentGetSchema(user_role_xref_id=904, user_id=904, role_id=992,
+            user=FamUserInfoSchema(user_name="tu_1", user_type_relation=FamUserTypeSchema(user_type_code=UserType.BCEID, description="dummy_desc")),
+            role=FamRoleWithClientSchema(role_id=992, role_name="r2_12345678", role_type_code=RoleType.ROLE_TYPE_CONCRETE, role_purpose="Test dummy role",
+                application=FamApplicationSchema(
+                    application_id=900, application_name="a1", application_description="dummy_app"
+                ), forest_client_relation=FamForestClientSchema(forest_client_number="12345678"), parent_role=FamRoleMinSchema(role_name="r2",
+                role_type_code=RoleType.ROLE_TYPE_ABSTRACT, application=FamApplicationSchema(application_id=900, application_name="a1",
+                application_description="dummy_app")
+            )),
+            create_date=datetime.datetime(2024, 11, 1, 19, 44, 47)), # FC exist in db but not valid (legacy data or not active)
     ]
 }


### PR DESCRIPTION
Ref: #1638 
FAM dev environment has server error because in TEST environment, there are some user/role database records contains forest_client_number that are not valid and is causing the forest_client_dec to fail because it cannot find/search the forest client to update for the client_name.

- Use .get() instead for getting item from python dict to prevent indexing not existing item.
- Update the test to cover this case.