### PR TITLE
ci: #1700 Fix Github Runners

### DIFF
--- a/.github/workflows/reusable_data_model_gen.yml
+++ b/.github/workflows/reusable_data_model_gen.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       user: ${{ steps.data.outputs.user }}
       pass: ${{ steps.data.outputs.pass }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Generate random username and password
@@ -24,7 +24,7 @@ jobs:
 
   schemaspy:
     name: Generate Documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [vars]
     services:
       postgres:

--- a/.github/workflows/reusable_terraform_frontend.yml
+++ b/.github/workflows/reusable_terraform_frontend.yml
@@ -33,6 +33,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: HashiCorp - Setup Terraform
+              uses: hashicorp/setup-terraform@v3.1.2
+
             - name: Build Frontend
               working-directory: frontend
               run: |

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -189,6 +189,7 @@ jobs:
               env:
                   licenceplate: ${{ secrets.licenceplate }}
                   target_env: ${{ inputs.environment_name }}
+
               run: |
                   # Run terraform
                   terragrunt run-all ${{ inputs.tf_subcommand }} --terragrunt-non-interactive

--- a/.github/workflows/reusable_terraform_server.yml
+++ b/.github/workflows/reusable_terraform_server.yml
@@ -181,6 +181,9 @@ jobs:
                   fam_update_user_info_api_key = "${{ secrets.fam_update_user_info_api_key }}"
                   EOF
 
+            - name: HashiCorp - Setup Terraform
+              uses: hashicorp/setup-terraform@v3.1.2
+
             - name: Terragrunt ${{ inputs.tf_subcommand }}
               working-directory: ${{ env.TG_SRC_PATH }}/${{ inputs.environment_name }}
               env:


### PR DESCRIPTION
Closes: #1700 

Github runner for the latest is switching and pointing to ubuntu-24.04. This remove several binaries from the image. Terraform deployment is failing by this removal.

- Install Terraform in GH Action workflow.

* This is recreated from #1702 due to branch naming was having trouble with Terraform deployment file code.