### PR TITLE
fix: Cloudfront tf deployment error

### DIFF
--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -100,10 +100,11 @@ locals {
     css  = "text/css",
     pdf  = "application/pdf"
   }
+  ignore_files = [".terragrunt-source-manifest","assets/.terragrunt-source-manifest","files/.terragrunt-source-manifest"]
   files_raw = fileset(local.src_dir, "**")
   files = toset([
     for jsFile in local.files_raw:
-      jsFile if jsFile != ".terragrunt-source-manifest" && jsFile != "assets/.terragrunt-source-manifest"
+      jsFile if !contains(ignore_files, jsFile)
   ])
 }
 

--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -97,7 +97,8 @@ locals {
     svg  = "image/svg+xml",
     ttf  = "font/ttf",
     txt  = "text/txt",
-    css  = "text/css"
+    css  = "text/css",
+    pdf  = "application/pdf"
   }
   files_raw = fileset(local.src_dir, "**")
   files = toset([

--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -104,7 +104,7 @@ locals {
   files_raw = fileset(local.src_dir, "**")
   files = toset([
     for jsFile in local.files_raw:
-      jsFile if !contains(ignore_files, jsFile)
+      jsFile if !contains(local.ignore_files, jsFile)
   ])
 }
 

--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -117,5 +117,5 @@ resource "aws_s3_bucket_object" "site_files" {
   source = "${local.src_dir}/${each.value}"
   etag = filemd5("${local.src_dir}/${each.value}")
 
-  content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9]+)$", each.value).extension, "application/octet-stream")
+  content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9_]+)$", each.value).extension, "application/octet-stream")
 }


### PR DESCRIPTION
The deployment failed with some Cloudfront Terraform error due to frontend build "dist" structure change (from new pdf files added at previous pr #1719) .
Few fixes at `cloudfront.tf` were included:
- file pattern to include "_ underscore".
- added additional "application/pdf" content type.
- needed to ignore **"files/.terragrunt-source-manifest"** for the Cloudfront site files due to new structure.