### PR TITLE
fix: #1737 AWS RDS postgresql engine version minor patch upgrade

### DIFF
--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -41,7 +41,7 @@ resource "aws_db_subnet_group" "famdb_subnet_group" {
 
 data "aws_rds_engine_version" "postgresql" {
   engine  = "aurora-postgresql"
-  version = "13.10"
+  version = "13.15"
 }
 
 module "aurora_postgresql_v2" {

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -41,7 +41,7 @@ resource "aws_db_subnet_group" "famdb_subnet_group" {
 
 data "aws_rds_engine_version" "postgresql" {
   engine  = "aurora-postgresql"
-  version = "13.15"
+  version = "13.18"
 }
 
 module "aurora_postgresql_v2" {


### PR DESCRIPTION
ref: #1737 

Due to AWS 13.10 is now unavailable, we have to:
- upgrade postresql engine version from 13.10 to 13.18 (minor).

This version is currently deployed to DEV for testing.
![image](https://github.com/user-attachments/assets/ad58bc36-9cb7-42cd-b340-dcf7fcaaf158)
