### PR TITLE
fix: #1647 Fix migration for backend timestamp columns consistency

### DIFF
--- a/server/flyway/sql/V60__timestamp_columns_consistency.sql
+++ b/server/flyway/sql/V60__timestamp_columns_consistency.sql
@@ -64,6 +64,10 @@ ALTER TABLE app_fam.fam_application_admin
 
 
 -- >> -- Table: fam_application_group_xref -- << --
+-- Update existing NULL values
+UPDATE app_fam.fam_application_group_xref
+    SET update_date = create_date WHERE update_date IS NULL;
+
 -- Set NOT NULL constraint
 ALTER TABLE app_fam.fam_application_group_xref
     ALTER COLUMN update_date SET NOT NULL;
@@ -80,12 +84,21 @@ ALTER TABLE app_fam.fam_forest_client
 
 
 --  >> -- Table: fam_group -- <<--
+-- Update existing NULL values
+UPDATE app_fam.fam_group
+    SET update_date = create_date WHERE update_date IS NULL;
+
 -- Set NOT NULL constraint
 ALTER TABLE app_fam.fam_group
     ALTER COLUMN update_date SET NOT NULL;
 
 
 -- >> -- Table: fam_group_role_xref -- << --
+-- Update existing NULL values
+UPDATE app_fam.fam_group_role_xref
+    SET update_date = create_date WHERE update_date IS NULL;
+
+-- Set NOT NULL constraint
 ALTER TABLE app_fam.fam_group_role_xref
     ALTER COLUMN update_date SET NOT NULL;
 
@@ -113,6 +126,11 @@ ALTER TABLE app_fam.fam_privilege_change_type
 
 
 -- >> -- Table: fam_role -- << --
+
+-- Update existing NULL values (update_date with create_date if null)
+UPDATE app_fam.fam_role
+    SET update_date = create_date WHERE update_date IS NULL;
+
 -- Set NOT NULL constraint
 ALTER TABLE app_fam.fam_role
     ALTER COLUMN update_date SET NOT NULL;
@@ -141,6 +159,10 @@ ALTER TABLE app_fam.fam_user
 
 
 -- >> -- Table: fam_user_group_xref -- << --
+-- Update existing NULL values
+UPDATE app_fam.fam_user_group_xref
+    SET update_date = create_date WHERE update_date IS NULL;
+
 -- Set NOT NULL constraint
 ALTER TABLE app_fam.fam_user_group_xref
     ALTER COLUMN update_date SET DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
ref: #1647 

The V60 flyway (on previous pr: https://github.com/bcgov/nr-forests-access-management/pull/1722) missed the scenario that for existing `fam_role` table data, some could have null value for `update_date` before updating the column to NOT NULL.
While locally does not have such data, but deployment to DEV failed. I checked the flyway history in DEV, V60 was get recorded in history because it was failed; so I feel we still can change V60 migration script.

- update the `update_date` column value on several table to be safe for flyway before setting column constraint to NOT NULL.