### PR TITLE
fix: #1740 AWS RDS postgresql engine major version upgrade

### DIFF
--- a/docker-base-services.yml
+++ b/docker-base-services.yml
@@ -6,50 +6,50 @@
 #
 ---
 services:
-  fam-database:
-    image: postgres:14.1-alpine
-    mem_limit: 128m
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=fam
-      - POSTGRES_HOST_AUTH_METHOD=password
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
-      timeout: 5s
-      retries: 6
-    networks:
-      - fam
+    fam-database:
+        image: postgres:17.4-alpine
+        mem_limit: 128m
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=postgres
+            - POSTGRES_DB=fam
+            - POSTGRES_HOST_AUTH_METHOD=password
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 5s
+            timeout: 5s
+            retries: 6
+        networks:
+            - fam
 
-  fam-flyway:
-    build:
-      context: server/flyway
-      dockerfile: Dockerfile
-    environment:
-      - FLYWAY_USER=postgres
-      - FLYWAY_PASSWORD=postgres
-      - FLYWAY_BASELINE_ON_MIGRATE=true
-      - FLYWAY_PLACEHOLDERS_api_db_username=fam_proxy_api
-      - FLYWAY_PLACEHOLDERS_api_db_password=test
-      - FLYWAY_PLACEHOLDERS_admin_management_api_db_user=fam_admin_management_api
-      - FLYWAY_PLACEHOLDERS_admin_management_api_db_password=test
-      - FLYWAY_PLACEHOLDERS_client_id_fom_public="nolongerinuse1"
-      - FLYWAY_PLACEHOLDERS_client_id_fom_ministry="nolongerinuse2"
-      - FLYWAY_PLACEHOLDERS_client_id_fam_console=26tltjjfe7ktm4bte7av998d78
-      - FLYWAY_PLACEHOLDERS_client_id_dev_fom_oidc_client=1a8pkq0psq0daj5e6ir3ppcjkj
-      - FLYWAY_PLACEHOLDERS_client_id_test_fom_oidc_client=7b6eki43nahus9ca0lhjs6m568
-      - FLYWAY_PLACEHOLDERS_client_id_prod_fom_oidc_client=1rhdfiek5ntmk2kg39d6e31p46
-      - FLYWAY_PLACEHOLDERS_client_id_dev_spar_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZOt
-      - FLYWAY_PLACEHOLDERS_client_id_test_spar_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAna2
-      - FLYWAY_PLACEHOLDERS_client_id_prod_spar_oidc_client=KdnD2eGS3Zcx494p04yMFhDwSf
-      - FLYWAY_PLACEHOLDERS_client_id_dev_forest_client_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZOg
-      - FLYWAY_PLACEHOLDERS_client_id_test_forest_client_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAnah
-      - FLYWAY_PLACEHOLDERS_client_id_prod_forest_client_oidc_client=KdnD2eGS3Zcx494p04yMFhDwSe
-      - FLYWAY_PLACEHOLDERS_client_id_dev_silva_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZO5
-      - FLYWAY_PLACEHOLDERS_client_id_test_silva_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAna5
-      - FLYWAY_PLACEHOLDERS_client_id_prod_silva_oidc_client=KdnD2eGS3Zcx494p04yMFhDwS5
-      - FLYWAY_PLACEHOLDERS_auth_lambda_db_user=fam_auth_lambda
-      - FLYWAY_PLACEHOLDERS_auth_lambda_db_password=test
-    networks:
-      - fam
+    fam-flyway:
+        build:
+            context: server/flyway
+            dockerfile: Dockerfile
+        environment:
+            - FLYWAY_USER=postgres
+            - FLYWAY_PASSWORD=postgres
+            - FLYWAY_BASELINE_ON_MIGRATE=true
+            - FLYWAY_PLACEHOLDERS_api_db_username=fam_proxy_api
+            - FLYWAY_PLACEHOLDERS_api_db_password=test
+            - FLYWAY_PLACEHOLDERS_admin_management_api_db_user=fam_admin_management_api
+            - FLYWAY_PLACEHOLDERS_admin_management_api_db_password=test
+            - FLYWAY_PLACEHOLDERS_client_id_fom_public="nolongerinuse1"
+            - FLYWAY_PLACEHOLDERS_client_id_fom_ministry="nolongerinuse2"
+            - FLYWAY_PLACEHOLDERS_client_id_fam_console=26tltjjfe7ktm4bte7av998d78
+            - FLYWAY_PLACEHOLDERS_client_id_dev_fom_oidc_client=1a8pkq0psq0daj5e6ir3ppcjkj
+            - FLYWAY_PLACEHOLDERS_client_id_test_fom_oidc_client=7b6eki43nahus9ca0lhjs6m568
+            - FLYWAY_PLACEHOLDERS_client_id_prod_fom_oidc_client=1rhdfiek5ntmk2kg39d6e31p46
+            - FLYWAY_PLACEHOLDERS_client_id_dev_spar_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZOt
+            - FLYWAY_PLACEHOLDERS_client_id_test_spar_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAna2
+            - FLYWAY_PLACEHOLDERS_client_id_prod_spar_oidc_client=KdnD2eGS3Zcx494p04yMFhDwSf
+            - FLYWAY_PLACEHOLDERS_client_id_dev_forest_client_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZOg
+            - FLYWAY_PLACEHOLDERS_client_id_test_forest_client_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAnah
+            - FLYWAY_PLACEHOLDERS_client_id_prod_forest_client_oidc_client=KdnD2eGS3Zcx494p04yMFhDwSe
+            - FLYWAY_PLACEHOLDERS_client_id_dev_silva_oidc_client=xxqiHFmwG8j1cVAz7NgtknaZO5
+            - FLYWAY_PLACEHOLDERS_client_id_test_silva_oidc_client=dm5Xkmomnq0gbwBiXiN5LgAna5
+            - FLYWAY_PLACEHOLDERS_client_id_prod_silva_oidc_client=KdnD2eGS3Zcx494p04yMFhDwS5
+            - FLYWAY_PLACEHOLDERS_auth_lambda_db_user=fam_auth_lambda
+            - FLYWAY_PLACEHOLDERS_auth_lambda_db_password=test
+        networks:
+            - fam

--- a/docker-base-services.yml
+++ b/docker-base-services.yml
@@ -7,7 +7,7 @@
 ---
 services:
     fam-database:
-        image: postgres:17.4-alpine
+        image: postgres:16.6-alpine
         mem_limit: 128m
         environment:
             - POSTGRES_USER=postgres

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -72,8 +72,8 @@ module "aurora_postgresql_v2" {
   skip_final_snapshot = true
   auto_minor_version_upgrade = false
 
-  db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql13.id
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql13.id
+  db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql.id
 
   serverlessv2_scaling_configuration = {
     min_capacity = 0.5
@@ -93,7 +93,7 @@ module "aurora_postgresql_v2" {
   enabled_cloudwatch_logs_exports = ["postgresql"]
 }
 
-resource "aws_db_parameter_group" "famdb_postgresql13" {
+resource "aws_db_parameter_group" "famdb_postgresql" {
   name        = "${var.famdb_cluster_name}-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-parameter-group"
@@ -102,7 +102,7 @@ resource "aws_db_parameter_group" "famdb_postgresql13" {
   }
 }
 
-resource "aws_rds_cluster_parameter_group" "famdb_postgresql13" {
+resource "aws_rds_cluster_parameter_group" "famdb_postgresql" {
   name        = "${var.famdb_cluster_name}-cluster-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-cluster-parameter-group"

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -94,20 +94,30 @@ module "aurora_postgresql_v2" {
 }
 
 resource "aws_db_parameter_group" "famdb_postgresql" {
-  name        = "${var.famdb_cluster_name}-parameter-group"
+  # name        = "${var.famdb_cluster_name}-parameter-group"
+  name_prefix = "${var.famdb_cluster_name}-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-parameter-group"
   tags = {
     managed-by = "terraform"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_rds_cluster_parameter_group" "famdb_postgresql" {
-  name        = "${var.famdb_cluster_name}-cluster-parameter-group"
+  # name        = "${var.famdb_cluster_name}-cluster-parameter-group"
+  name_prefix = "${var.famdb_cluster_name}-cluster-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-cluster-parameter-group"
   tags = {
     managed-by = "terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -41,7 +41,7 @@ resource "aws_db_subnet_group" "famdb_subnet_group" {
 
 data "aws_rds_engine_version" "postgresql" {
   engine  = "aurora-postgresql"
-  version = "17.4"
+  version = "16.8"
 }
 
 module "aurora_postgresql_v2" {
@@ -72,8 +72,8 @@ module "aurora_postgresql_v2" {
   skip_final_snapshot = true
   auto_minor_version_upgrade = false
 
-  db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql13.id
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql13.id
+  db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql.id
 
   serverlessv2_scaling_configuration = {
     min_capacity = 0.5
@@ -93,18 +93,18 @@ module "aurora_postgresql_v2" {
   enabled_cloudwatch_logs_exports = ["postgresql"]
 }
 
-resource "aws_db_parameter_group" "famdb_postgresql13" {
+resource "aws_db_parameter_group" "famdb_postgresql" {
   name        = "${var.famdb_cluster_name}-parameter-group"
-  family      = "aurora-postgresql13"
+  family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-parameter-group"
   tags = {
     managed-by = "terraform"
   }
 }
 
-resource "aws_rds_cluster_parameter_group" "famdb_postgresql13" {
+resource "aws_rds_cluster_parameter_group" "famdb_postgresql" {
   name        = "${var.famdb_cluster_name}-cluster-parameter-group"
-  family      = "aurora-postgresql13"
+  family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-cluster-parameter-group"
   tags = {
     managed-by = "terraform"

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -94,7 +94,6 @@ module "aurora_postgresql_v2" {
 }
 
 resource "aws_db_parameter_group" "famdb_postgresql" {
-  # name        = "${var.famdb_cluster_name}-parameter-group"
   name_prefix = "${var.famdb_cluster_name}-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-parameter-group"
@@ -108,7 +107,6 @@ resource "aws_db_parameter_group" "famdb_postgresql" {
 }
 
 resource "aws_rds_cluster_parameter_group" "famdb_postgresql" {
-  # name        = "${var.famdb_cluster_name}-cluster-parameter-group"
   name_prefix = "${var.famdb_cluster_name}-cluster-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-cluster-parameter-group"

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -41,7 +41,7 @@ resource "aws_db_subnet_group" "famdb_subnet_group" {
 
 data "aws_rds_engine_version" "postgresql" {
   engine  = "aurora-postgresql"
-  version = "16.8"
+  version = "16.6"
 }
 
 module "aurora_postgresql_v2" {

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -72,8 +72,8 @@ module "aurora_postgresql_v2" {
   skip_final_snapshot = true
   auto_minor_version_upgrade = false
 
-  db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql.id
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql.id
+  db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql13.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql13.id
 
   serverlessv2_scaling_configuration = {
     min_capacity = 0.5
@@ -93,7 +93,7 @@ module "aurora_postgresql_v2" {
   enabled_cloudwatch_logs_exports = ["postgresql"]
 }
 
-resource "aws_db_parameter_group" "famdb_postgresql" {
+resource "aws_db_parameter_group" "famdb_postgresql13" {
   name        = "${var.famdb_cluster_name}-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-parameter-group"
@@ -102,7 +102,7 @@ resource "aws_db_parameter_group" "famdb_postgresql" {
   }
 }
 
-resource "aws_rds_cluster_parameter_group" "famdb_postgresql" {
+resource "aws_rds_cluster_parameter_group" "famdb_postgresql13" {
   name        = "${var.famdb_cluster_name}-cluster-parameter-group"
   family      = "aurora-postgresql16"
   description = "${var.famdb_cluster_name}-cluster-parameter-group"

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -41,7 +41,7 @@ resource "aws_db_subnet_group" "famdb_subnet_group" {
 
 data "aws_rds_engine_version" "postgresql" {
   engine  = "aurora-postgresql"
-  version = "13.18"
+  version = "17.4"
 }
 
 module "aurora_postgresql_v2" {


### PR DESCRIPTION
#1740 
- adjusted docker db image to `17.4` (although not the same with db version at AWS aurora-postgresql enginer version).
- adjusted `aurora-v2.tf` for:
  - engine_version upgrade: 16.6 (from 13.8)
  - renamed parameter_group resource name to have just general name (previously was `"famdb_postgresql13"`) and it is hard to change in future.
  - used `name_prefix` for parameter_group naming instead of `name` to prevent Terraform error when changing engine family (resource group already exists error).
  - adjusted parameter_group engine family to `family = "aurora-postgresql16"` to match engine_version.