### PR TITLE
fix: #1740Add allow_major_version_upgrade to resolve terraform failure.

### DIFF
--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -71,6 +71,7 @@ module "aurora_postgresql_v2" {
   apply_immediately   = true
   skip_final_snapshot = true
   auto_minor_version_upgrade = false
+  allow_major_version_upgrade = true
 
   db_parameter_group_name         = aws_db_parameter_group.famdb_postgresql.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql.id

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -78,7 +78,7 @@ module "aurora_postgresql_v2" {
 
   serverlessv2_scaling_configuration = {
     min_capacity = 0.5
-    max_capacity = 1
+    max_capacity = 4
   }
 
   instance_class = "db.serverless"


### PR DESCRIPTION
ref: #1740 
Deployment previously encountered error for a flag needs to be set.
![image](https://github.com/user-attachments/assets/3aafc7fd-7390-41cf-bde7-2c9d28450f99)
This did not happen when experimenting on AWS Tool deployment. Perhaps it was because in Tools space the database was actually removed (although there were still parameter_group...