### PR TITLE
fix: Add Cognito User Pool custom id and access tokens attributes

### DIFF
--- a/infrastructure/server/user_pool.tf
+++ b/infrastructure/server/user_pool.tf
@@ -132,6 +132,32 @@ resource "aws_cognito_user_pool" "fam_user_pool" {
     }
   }
 
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = "false"
+    mutable                  = "true"
+    name                     = "id_token"
+    required                 = "false"
+
+    string_attribute_constraints {
+      max_length = "2048"
+      min_length = "0"
+    }
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = "false"
+    mutable                  = "true"
+    name                     = "access_token"
+    required                 = "false"
+
+    string_attribute_constraints {
+      max_length = "2048"
+      min_length = "0"
+    }
+  }
+
   username_configuration {
     case_sensitive = "false"
   }

--- a/infrastructure/server/user_pool.tf
+++ b/infrastructure/server/user_pool.tf
@@ -133,6 +133,8 @@ resource "aws_cognito_user_pool" "fam_user_pool" {
   }
 
   schema {
+    # custom:id_token is added due to troubleshooting user pool user attributes issue.
+    # This does not need to be mapped to IDP/APP Client attributes mapping.
     attribute_data_type      = "String"
     developer_only_attribute = "false"
     mutable                  = "true"
@@ -146,6 +148,8 @@ resource "aws_cognito_user_pool" "fam_user_pool" {
   }
 
   schema {
+    # custom:access_token is added due to troubleshooting user pool user attributes issue.
+    # This does not need to be mapped to IDP/APP Client attributes mapping.
     attribute_data_type      = "String"
     developer_only_attribute = "false"
     mutable                  = "true"


### PR DESCRIPTION
Previously when troubleshooting Cognito User Pool user attributes missing, we added `custom:id_token` and `custom:access_token` at AWS DEV Cognito User Pool. These custom attributes cannot be deleted from AWS and currently are causing Terraform run failure (https://github.com/bcgov/nr-forests-access-management/actions/runs/13668845435/job/38257696930) at DEV deployment.
After discussion, we decided to:
- add `custom:id_token` and `custom:access_token` to Cognito User Pool to stop the failure but these attributes will not be mapped.