### PR TITLE
feat: #1773 Change redirect_uri to post_logout_redirect_uri

### DIFF
--- a/frontend/public/env.json
+++ b/frontend/public/env.json
@@ -32,7 +32,7 @@
     "frontend_logout_chain_url": {
         "sensitive": false,
         "type": "string",
-        "value": "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+        "value": "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?post_logout_redirect_uri="
     },
     "front_end_redirect_base_url": {
         "sensitive": false,

--- a/terraform/common_vars.hcl
+++ b/terraform/common_vars.hcl
@@ -2,10 +2,10 @@
 
 inputs = {
   # Cognito App Clients common vars.
-  idp_logout_chain_dev_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
-  idp_logout_chain_test_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
-  idp_logout_chain_prod_url = "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
-  idp_logout_chain_tools_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+  idp_logout_chain_dev_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?post_logout_redirect_uri="
+  idp_logout_chain_test_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?post_logout_redirect_uri="
+  idp_logout_chain_prod_url = "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?post_logout_redirect_uri="
+  idp_logout_chain_tools_url = "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?post_logout_redirect_uri="
 
   # Forest Clients API Search common configs.
   forest_client_api_test_base_url = "https://nr-forest-client-api-test.api.gov.bc.ca"


### PR DESCRIPTION
Required due to Keycloak upgrade.
Not setting the idp_token_hint parameter as the OIDC spec says it is recommended but not mandatory. (https://openid.net/specs/openid-connect-rpinitiated-1_0.html).
This is intended to be the smallest change that should work with the upgrade.