### PR TITLE
fix: #1763 Adjust Cognito app clients read/write attributes

### DIFF
--- a/infrastructure/server/oidc_clients_apt.tf
+++ b/infrastructure/server/oidc_clients_apt.tf
@@ -19,7 +19,7 @@ resource "aws_cognito_user_pool_client" "dev_apt_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "apt_dev"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}"
@@ -32,7 +32,7 @@ resource "aws_cognito_user_pool_client" "dev_apt_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "test_apt_oidc_client" {
@@ -56,7 +56,7 @@ resource "aws_cognito_user_pool_client" "test_apt_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "apt_test"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}"
@@ -69,7 +69,7 @@ resource "aws_cognito_user_pool_client" "test_apt_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "prod_apt_oidc_client" {
@@ -91,7 +91,7 @@ resource "aws_cognito_user_pool_client" "prod_apt_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "apt_prod"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}"
@@ -104,5 +104,5 @@ resource "aws_cognito_user_pool_client" "prod_apt_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }

--- a/infrastructure/server/oidc_clients_fam.tf
+++ b/infrastructure/server/oidc_clients_fam.tf
@@ -1,3 +1,8 @@
+/*
+User OIDC attributes, FAM includes:
+  - minimum_oidc_attribute_list: required for all OIDC clients
+  - custom:idp_business_name: FAM uses this attribute to display user's organization name.
+*/
 resource "aws_cognito_user_pool_client" "fam_console_oidc_client" {
   access_token_validity                = "5"
   allowed_oauth_flows                  = ["code"]

--- a/infrastructure/server/oidc_clients_fam.tf
+++ b/infrastructure/server/oidc_clients_fam.tf
@@ -20,7 +20,7 @@ resource "aws_cognito_user_pool_client" "fam_console_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "fam_console"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email", "custom:idp_business_id", "custom:idp_business_name"])
+  read_attributes                               = concat(var.minimum_oidc_attribute_list, ["custom:idp_business_name"])
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [var.fam_console_idp_name, var.fam_console_idp_name_bceid]
 
@@ -31,7 +31,7 @@ resource "aws_cognito_user_pool_client" "fam_console_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email", "custom:idp_business_id", "custom:idp_business_name"])
+  write_attributes = concat(var.minimum_oidc_attribute_list, ["custom:idp_business_name"])
 
   depends_on = [
     aws_cognito_identity_provider.dev_idir_oidc_provider,

--- a/infrastructure/server/oidc_clients_fom.tf
+++ b/infrastructure/server/oidc_clients_fom.tf
@@ -21,7 +21,7 @@ resource "aws_cognito_user_pool_client" "dev_fom_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "fom_dev"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
@@ -35,7 +35,7 @@ resource "aws_cognito_user_pool_client" "dev_fom_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "test_fom_oidc_client" {
@@ -60,7 +60,7 @@ resource "aws_cognito_user_pool_client" "test_fom_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "fom_test"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
@@ -74,7 +74,7 @@ resource "aws_cognito_user_pool_client" "test_fom_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "prod_fom_oidc_client" {
@@ -96,7 +96,7 @@ resource "aws_cognito_user_pool_client" "prod_fom_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "fom_prod"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
@@ -110,5 +110,5 @@ resource "aws_cognito_user_pool_client" "prod_fom_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }

--- a/infrastructure/server/oidc_clients_results_exam.tf
+++ b/infrastructure/server/oidc_clients_results_exam.tf
@@ -21,7 +21,7 @@ resource "aws_cognito_user_pool_client" "dev_results_exam_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "results_exam_dev"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
@@ -35,7 +35,7 @@ resource "aws_cognito_user_pool_client" "dev_results_exam_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "test_results_exam_oidc_client" {
@@ -59,7 +59,7 @@ resource "aws_cognito_user_pool_client" "test_results_exam_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "results_exam_test"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
@@ -73,7 +73,7 @@ resource "aws_cognito_user_pool_client" "test_results_exam_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "prod_results_exam_oidc_client" {
@@ -95,7 +95,7 @@ resource "aws_cognito_user_pool_client" "prod_results_exam_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "results_exam_prod"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
@@ -109,5 +109,5 @@ resource "aws_cognito_user_pool_client" "prod_results_exam_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }

--- a/infrastructure/server/oidc_clients_silva.tf
+++ b/infrastructure/server/oidc_clients_silva.tf
@@ -21,7 +21,7 @@ resource "aws_cognito_user_pool_client" "dev_silva_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "silva_dev"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
@@ -35,7 +35,7 @@ resource "aws_cognito_user_pool_client" "dev_silva_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "test_silva_oidc_client" {
@@ -61,7 +61,7 @@ resource "aws_cognito_user_pool_client" "test_silva_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "silva_test"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
@@ -75,7 +75,7 @@ resource "aws_cognito_user_pool_client" "test_silva_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "prod_silva_oidc_client" {
@@ -99,7 +99,7 @@ resource "aws_cognito_user_pool_client" "prod_silva_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "silva_prod"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
@@ -113,5 +113,5 @@ resource "aws_cognito_user_pool_client" "prod_silva_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }

--- a/infrastructure/server/oidc_clients_spar.tf
+++ b/infrastructure/server/oidc_clients_spar.tf
@@ -20,7 +20,7 @@ resource "aws_cognito_user_pool_client" "dev_spar_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "spar_dev"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
@@ -34,7 +34,7 @@ resource "aws_cognito_user_pool_client" "dev_spar_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "test_spar_oidc_client" {
@@ -66,7 +66,7 @@ resource "aws_cognito_user_pool_client" "test_spar_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "spar_test"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
@@ -80,7 +80,7 @@ resource "aws_cognito_user_pool_client" "test_spar_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }
 
 resource "aws_cognito_user_pool_client" "prod_spar_oidc_client" {
@@ -104,7 +104,7 @@ resource "aws_cognito_user_pool_client" "prod_spar_oidc_client" {
   id_token_validity                             = "60"
   name                                          = "spar_prod"
   prevent_user_existence_errors                 = "ENABLED"
-  read_attributes                               = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  read_attributes                               = var.minimum_oidc_attribute_list
   refresh_token_validity                        = "24"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
@@ -118,5 +118,5 @@ resource "aws_cognito_user_pool_client" "prod_spar_oidc_client" {
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
-  write_attributes = "${concat(var.minimum_oidc_attribute_list, ["custom:idp_display_name", "email"])}"
+  write_attributes = var.minimum_oidc_attribute_list
 }

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -259,7 +259,13 @@ variable "fam_console_idp_name_bceid" {
   type = string
 }
 
-// Required for all OIDC clients
+/*
+  Note!: Required for all OIDC clients.
+  All attributes of the user gets stored/updated in FAM_USER table must be part of the
+  minimum attribute set used by all applications. This is to avoid attributes being
+  overriden (when the same user can login through different app clients) on Cognito User
+  Pool for that user and avoid attributes being overriden into FAM_USER table.
+*/
 variable "minimum_oidc_attribute_list" {
   description = "Required fields for FAM clients to be able to read and write"
   type        = list(string)

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -262,7 +262,11 @@ variable "fam_console_idp_name_bceid" {
 variable "minimum_oidc_attribute_list" {
   description = "Required fields for FAM clients to be able to read and write"
   type        = list(string)
-  default     = ["custom:idp_name", "custom:idp_user_id", "custom:idp_username"]
+  default     = [
+    "custom:idp_name", "custom:idp_user_id", "custom:idp_username",
+    "custom:idp_business_id", "custom:idp_display_name", "email",
+    "given_name", "family_name"
+  ]
 }
 
 variable "maximum_oidc_attribute_read_list" {

--- a/infrastructure/server/variables_provided.tf
+++ b/infrastructure/server/variables_provided.tf
@@ -259,6 +259,7 @@ variable "fam_console_idp_name_bceid" {
   type = string
 }
 
+// Required for all OIDC clients
 variable "minimum_oidc_attribute_list" {
   description = "Required fields for FAM clients to be able to read and write"
   type        = list(string)


### PR DESCRIPTION
closes: #1763 

Adjust Cognito App Clients read/write attributes to be consistent to avoid User Pools users necessary attributes missing when log on to different clients.

- updated `minimum_oidc_attribute_list` to include: `custom:idp_business_id`, `email`, `custom:idp_display_name`, `given_name`, `family_name`.
- adjusted all App Clients on Terraform file to reflect the change above.

Note: the `forest_client` App Client was having maximum attributes initially (unclear for the reason why it is very different than others) so no change for this app client.