### PR TITLE
fix: #1798 Add V63 flyway script for APT display name update.

### DIFF
--- a/server/flyway/sql/V63__update_apt_app_role_display_name.sql
+++ b/server/flyway/sql/V63__update_apt_app_role_display_name.sql
@@ -1,9 +1,9 @@
 -- Update app_fam.fam_role.display_name for application 'APT'
 
 -- APT 'VIEWER' role -> display_name: "View"
-UPDATE app_fam.fam_role SET DISPLAY_NAME = 'View' WHERE APPLICATION_ID in
+UPDATE app_fam.fam_role SET DISPLAY_NAME = 'Viewer' WHERE APPLICATION_ID in
     (select APPLICATION_ID from app_fam.fam_application where APPLICATION_NAME LIKE 'APT_%') AND ROLE_NAME = 'VIEWER';
 
 -- APT 'EDITOR' role -> display_name: "Update"
-UPDATE app_fam.fam_role SET DISPLAY_NAME = 'Update' WHERE APPLICATION_ID in
+UPDATE app_fam.fam_role SET DISPLAY_NAME = 'Editor' WHERE APPLICATION_ID in
     (select APPLICATION_ID from app_fam.fam_application where APPLICATION_NAME LIKE 'APT_%') AND ROLE_NAME = 'EDITOR';

--- a/server/flyway/sql/V63__update_apt_app_role_display_name.sql
+++ b/server/flyway/sql/V63__update_apt_app_role_display_name.sql
@@ -1,0 +1,9 @@
+-- Update app_fam.fam_role.display_name for application 'APT'
+
+-- APT 'VIEWER' role -> display_name: "View"
+UPDATE app_fam.fam_role SET DISPLAY_NAME = 'View' WHERE APPLICATION_ID in
+    (select APPLICATION_ID from app_fam.fam_application where APPLICATION_NAME LIKE 'APT_%') AND ROLE_NAME = 'VIEWER';
+
+-- APT 'EDITOR' role -> display_name: "Update"
+UPDATE app_fam.fam_role SET DISPLAY_NAME = 'Update' WHERE APPLICATION_ID in
+    (select APPLICATION_ID from app_fam.fam_application where APPLICATION_NAME LIKE 'APT_%') AND ROLE_NAME = 'EDITOR';


### PR DESCRIPTION
ref: #1798 (Adding User to APT Application Error):
Currently any Application Admin has problem adding users to APT role from FAM.
Issue is identified for missing display_name in fam_role table for APT application.

- Add flyway V63 to update APT fam_role for its missing display_name.