### PR TITLE
fix: #1740 AWS rds postgresql engine major version upgrade post release

### DIFF
--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -78,7 +78,7 @@ module "aurora_postgresql_v2" {
 
   serverlessv2_scaling_configuration = {
     min_capacity = 0.5
-    max_capacity = 4
+    max_capacity = 1
   }
 
   instance_class = "db.serverless"
@@ -117,34 +117,6 @@ resource "aws_db_parameter_group" "famdb_postgresql16" {
   }
 
   # add this in case of failure
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-
-# Keep v13 before 16 kicks in and in effect
-resource "aws_db_parameter_group" "famdb_postgresql13" {
-  name        = "${var.famdb_cluster_name}-parameter-group"
-  family      = "aurora-postgresql13"
-  description = "${var.famdb_cluster_name}-parameter-group"
-  tags = {
-    managed-by = "terraform"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_rds_cluster_parameter_group" "famdb_postgresql13" {
-  name        = "${var.famdb_cluster_name}-cluster-parameter-group"
-  family      = "aurora-postgresql13"
-  description = "${var.famdb_cluster_name}-cluster-parameter-group"
-  tags = {
-    managed-by = "terraform"
-  }
-
   lifecycle {
     create_before_destroy = true
   }

--- a/infrastructure/server/aurora-v2.tf
+++ b/infrastructure/server/aurora-v2.tf
@@ -71,7 +71,7 @@ module "aurora_postgresql_v2" {
   apply_immediately   = true
   skip_final_snapshot = true
   auto_minor_version_upgrade = false
-  allow_major_version_upgrade = true
+  allow_major_version_upgrade = false
 
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.famdb_postgresql16.id
   db_cluster_db_instance_parameter_group_name = aws_db_parameter_group.famdb_postgresql16.id


### PR DESCRIPTION
ref: #1740 
Post release to clean up and to back to normal configuration:

* decrease max_capacity = 1
* remove previous old version v13 _parameter_group
* allow_major_version_upgrade = false