### PR TITLE
fix: #1821 FOM test environment logout url change.

### DIFF
--- a/infrastructure/server/oidc_clients_fom.tf
+++ b/infrastructure/server/oidc_clients_fom.tf
@@ -50,8 +50,7 @@ resource "aws_cognito_user_pool_client" "test_fom_oidc_client" {
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.test}https://fom-test.nrs.gov.bc.ca/admin/not-authorized?loggedout=true",
-    "${var.cognito_app_client_logout_chain_url.test}https://fom-demo.apps.silver.devops.gov.bc.ca/admin/not-authorized?loggedout=true"
+    "${var.cognito_app_client_logout_chain_url.test}https://fom-test.apps.silver.devops.gov.bc.ca/admin/not-authorized?loggedout=true",
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"


### PR DESCRIPTION
ref: #1821 
- Missed the change for FOM test logout url change last time. Adjusted it in this pr.
- Also remove 'demo' logout.