### PR TITLE
fix: #1829 modify silva dev and test login logout urls

### DIFF
--- a/infrastructure/server/oidc_clients_silva.tf
+++ b/infrastructure/server/oidc_clients_silva.tf
@@ -59,7 +59,7 @@ resource "aws_cognito_user_pool_client" "test_silva_oidc_client" {
     [
       var.oidc_sso_playground_url,
       "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000/",
-      "${var.cognito_app_client_logout_chain_url.test}http://localhost:4173/"
+      "${var.cognito_app_client_logout_chain_url.test}http://localhost:4173/",
       "${var.cognito_app_client_logout_chain_url.test}https://nr-silva-test-frontend.apps.silver.devops.gov.bc.ca/",
       "${var.cognito_app_client_logout_chain_url.test}https://silva-test.nrs.gov.bc.ca/"
     ],


### PR DESCRIPTION
Completes #1829

## Description
- Add the 50 PR URLs to the Silva Test config
- Add localhost:4173 to both Silva Dev and Test configs