### PR TITLE
fix: #1846 added terraform required provider version

### DIFF
--- a/infrastructure/frontend/version.tf
+++ b/infrastructure/frontend/version.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.99.1"
+    }
+  }
+}

--- a/infrastructure/server/version.tf
+++ b/infrastructure/server/version.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.99.1"
+    }
+  }
+}


### PR DESCRIPTION
I picked v5.99.1 for now as this is the version that we used for the [last successful deployment in PROD](https://github.com/bcgov/nr-forests-access-management/actions/runs/15477253127/job/43575553582).

Tested the deployment in Tools namespace, works fine https://github.com/bcgov/nr-forests-access-management/actions/runs/15766641334