### PR TITLE
Fix: Rename "Admin" to "Application Admin" in My Permissions table

### DIFF
--- a/frontend/src/components/MyPermissionsTable/utils.ts
+++ b/frontend/src/components/MyPermissionsTable/utils.ts
@@ -25,7 +25,7 @@ const getFamAdminPermission = (
             {
                 application: famGrant.application.description,
                 env: famGrant.application.env,
-                role: "Admin",
+                role: "Application Admin",
             },
         ];
     }
@@ -38,7 +38,7 @@ const getAppAdminPermission = (
     return access.grants.map((grant: FamGrantDetailDto) => ({
         application: grant.application.description,
         env: grant.application.env,
-        role: "Admin",
+        role: "Application Admin",
     }));
 };
 


### PR DESCRIPTION
This fixes the issue [https://github.com/orgs/bcgov/projects/65/views/1?filterQuery=jazz&pane=issue&itemId=121036232&issue=bcgov%7Cnr-forests-access-management%7C1891](ISSUE #1891), where the "Admin" , needs to be shown as "Application Admin" in the Fam My Permissions Table.
<img width="1909" height="519" alt="image" src="https://github.com/user-attachments/assets/0a0953c5-3b4a-438a-a4a5-7a395742492c" />
