### PR TITLE
feat: #1920 lza migration for cloudfront

### DIFF
--- a/.github/workflows/lza_reusable_terraform_frontend.yml
+++ b/.github/workflows/lza_reusable_terraform_frontend.yml
@@ -1,0 +1,92 @@
+name: LZA Run Terraform (Frontend)
+
+on:
+    workflow_call:
+        inputs:
+            environment_name:
+                required: true
+                type: string
+            tf_subcommand:
+                required: true
+                type: string
+        secrets:
+            licenceplate:
+                required: true
+
+env:
+    TF_VERSION: 1.2.2
+    TG_VERSION: 0.37.1
+    TG_SRC_PATH: lza-infrastructure/landing-zone/frontend
+    TG_SERVER_SRC_PATH: lza-infrastructure/landing-zone/server
+    AWS_REGION: ca-central-1
+
+jobs:
+    aws-frontend-deployment:
+        name: Run Terraform to Deploy Frontend
+        runs-on: ubuntu-latest
+        environment: ${{ inputs.environment_name }}
+
+        env:
+            AWS_OIDC_GHA_ROLE: ${{ vars.FAM_GHA_LZA_ROLE }} # AWS-GHA OIDC auth role.
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: HashiCorp - Setup Terraform
+              uses: hashicorp/setup-terraform@v3.1.2
+              with:
+                terraform_version: ${{ env.TF_VERSION }}
+
+            - name: Build Frontend
+              working-directory: frontend
+              run: |
+                  npm run install-frontend
+                  npm run build
+                  mkdir ../lza-infrastructure/terraform/frontend/dist
+                  rsync -r dist/* ../lza-infrastructure/terraform/frontend/dist
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ env.AWS_OIDC_GHA_ROLE }}
+                  role-session-name: frontend-${{ inputs.environment_name }}-deployment
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Setup Terragrunt
+              uses: autero1/action-terragrunt@v3.0.2
+              with:
+                  terragrunt-version: ${{ env.TG_VERSION }}
+
+            - id: terragrunt-server-output
+              name: Terragrunt Server Output
+              working-directory: ${{ env.TG_SERVER_SRC_PATH }}/${{ inputs.environment_name }}
+              env:
+                  licenceplate: ${{ secrets.licenceplate }}
+                  target_env: ${{ inputs.environment_name }}
+              run: |
+                  # Run terraform
+                  cat > github.auto.tfvars <<EOF
+                  oidc_idir_idp_client_secret = "NA"
+                  oidc_bceid_business_idp_client_secret = "NA"
+                  db_cluster_snapshot_identifier = "NA"
+                  execute_flyway = false
+                  EOF
+                  terragrunt run-all output -json > ../../../../lza-infrastructure/terraform/frontend/dist/env.json
+
+            - id: terragrunt-server-output-test
+              working-directory: lza-infrastructure/terraform/frontend/dist
+              name: Terragrunt Server Output Verify
+              run: |
+                  echo "printing out contents of env.json"
+                  echo "===================================="
+                  cat env.json
+                  echo "===================================="
+
+            # - name: Terragrunt ${{ inputs.tf_subcommand }}
+            #   working-directory: ${{ env.TG_SRC_PATH }}/${{ inputs.environment_name }}
+            #   env:
+            #       licenceplate: ${{ secrets.licenceplate }}
+            #       target_env: ${{ inputs.environment_name }}
+            #   run: |
+            #       terragrunt run-all ${{ inputs.tf_subcommand }} --terragrunt-non-interactive

--- a/.github/workflows/lza_reusable_terraform_frontend.yml
+++ b/.github/workflows/lza_reusable_terraform_frontend.yml
@@ -89,10 +89,10 @@ jobs:
                   cat env.json
                   echo "===================================="
 
-            # - name: Terragrunt ${{ inputs.tf_subcommand }}
-            #   working-directory: ${{ env.TG_SRC_PATH }}/${{ inputs.environment_name }}
-            #   env:
-            #       licenceplate: ${{ secrets.licenceplate }}
-            #       target_env: ${{ inputs.environment_name }}
-            #   run: |
-            #       terragrunt run-all ${{ inputs.tf_subcommand }} --terragrunt-non-interactive
+            - name: Terragrunt ${{ inputs.tf_subcommand }}
+              working-directory: ${{ env.TG_SRC_PATH }}/${{ inputs.environment_name }}
+              env:
+                  licenceplate: ${{ secrets.licenceplate }}
+                  target_env: ${{ inputs.environment_name }}
+              run: |
+                  terragrunt run-all ${{ inputs.tf_subcommand }} --terragrunt-non-interactive

--- a/.github/workflows/lza_reusable_terraform_frontend.yml
+++ b/.github/workflows/lza_reusable_terraform_frontend.yml
@@ -20,7 +20,7 @@ on:
                 required: true
 
 env:
-    TF_VERSION: 1.2.2
+    TF_VERSION: 1.12.2
     TG_VERSION: 0.37.1
     TG_SRC_PATH: lza-infrastructure/landing-zone/frontend
     TG_SERVER_SRC_PATH: lza-infrastructure/landing-zone/server

--- a/.github/workflows/lza_reusable_terraform_frontend.yml
+++ b/.github/workflows/lza_reusable_terraform_frontend.yml
@@ -1,5 +1,11 @@
 name: LZA Run Terraform (Frontend)
 
+# When use GHA OIDC provider and for action to create the JWT, it is required to have the id-token: write permission
+# permission can be added at job level or workflow level. Ref: https://github.com/aws-actions/configure-aws-credentials#OIDC
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
 on:
     workflow_call:
         inputs:

--- a/.github/workflows/lza_tools_deployment.yml
+++ b/.github/workflows/lza_tools_deployment.yml
@@ -4,31 +4,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  # aws-tools-deployment-server:
-  #   uses: ./.github/workflows/lza_reusable_terraform_server.yml
-  #   with:
-  #     environment_name: tools
-  #     tf_subcommand: apply
-  #     execute_flyway: true
+  aws-tools-deployment-server:
+    uses: ./.github/workflows/lza_reusable_terraform_server.yml
+    with:
+      environment_name: tools
+      tf_subcommand: apply
+      execute_flyway: true
 
-  #   secrets:
-  #     licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
-  #     dev_oidc_idir_idp_client_secret: "${{ secrets.DEV_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-  #     test_oidc_idir_idp_client_secret: "${{ secrets.TEST_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-  #     prod_oidc_idir_idp_client_secret: "${{ secrets.PROD_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-  #     dev_oidc_bceid_business_idp_client_secret: "${{ secrets.DEV_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-  #     test_oidc_bceid_business_idp_client_secret: "${{ secrets.TEST_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-  #     prod_oidc_bceid_business_idp_client_secret: "${{ secrets.PROD_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-  #     forest_client_api_api_key_test: "${{ secrets.FOREST_CLIENT_API_API_KEY_TEST }}"
-  #     dev_oidc_bcsc_idp_client_secret: "${{ secrets.DEV_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-  #     test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-  #     prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-  #     idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
-  #     gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
-  #     fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
+    secrets:
+      licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
+      dev_oidc_idir_idp_client_secret: "${{ secrets.DEV_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+      test_oidc_idir_idp_client_secret: "${{ secrets.TEST_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+      prod_oidc_idir_idp_client_secret: "${{ secrets.PROD_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+      dev_oidc_bceid_business_idp_client_secret: "${{ secrets.DEV_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+      test_oidc_bceid_business_idp_client_secret: "${{ secrets.TEST_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+      prod_oidc_bceid_business_idp_client_secret: "${{ secrets.PROD_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+      forest_client_api_api_key_test: "${{ secrets.FOREST_CLIENT_API_API_KEY_TEST }}"
+      dev_oidc_bcsc_idp_client_secret: "${{ secrets.DEV_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+      test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+      prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+      idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+      gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
+      fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
 
   aws-tools-deployment-frontend:
-    # needs: aws-tools-deployment-server
+    needs: aws-tools-deployment-server
     uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
     with:
       environment_name: tools

--- a/.github/workflows/lza_tools_deployment.yml
+++ b/.github/workflows/lza_tools_deployment.yml
@@ -27,11 +27,11 @@ jobs:
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
       fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
 
-  # aws-tools-deployment-frontend:
-  #   needs: aws-tools-deployment-server
-  #   uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
-  #   with:
-  #     environment_name: tools
-  #     tf_subcommand: apply
-  #   secrets:
-  #     licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
+  aws-tools-deployment-frontend:
+    needs: aws-tools-deployment-server
+    uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
+    with:
+      environment_name: tools
+      tf_subcommand: apply
+    secrets:
+      licenceplate: ${{ secrets.LZA_LICENCEPLATE}}

--- a/.github/workflows/lza_tools_deployment.yml
+++ b/.github/workflows/lza_tools_deployment.yml
@@ -4,25 +4,34 @@ on:
   workflow_dispatch:
 
 jobs:
-  aws-tools-deployment-server:
-    uses: ./.github/workflows/lza_reusable_terraform_server.yml
+  # aws-tools-deployment-server:
+  #   uses: ./.github/workflows/lza_reusable_terraform_server.yml
+  #   with:
+  #     environment_name: tools
+  #     tf_subcommand: apply
+  #     execute_flyway: true
+
+  #   secrets:
+  #     licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
+  #     dev_oidc_idir_idp_client_secret: "${{ secrets.DEV_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+  #     test_oidc_idir_idp_client_secret: "${{ secrets.TEST_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+  #     prod_oidc_idir_idp_client_secret: "${{ secrets.PROD_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+  #     dev_oidc_bceid_business_idp_client_secret: "${{ secrets.DEV_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+  #     test_oidc_bceid_business_idp_client_secret: "${{ secrets.TEST_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+  #     prod_oidc_bceid_business_idp_client_secret: "${{ secrets.PROD_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+  #     forest_client_api_api_key_test: "${{ secrets.FOREST_CLIENT_API_API_KEY_TEST }}"
+  #     dev_oidc_bcsc_idp_client_secret: "${{ secrets.DEV_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+  #     test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+  #     prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+  #     idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+  #     gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
+  #     fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
+
+  aws-tools-deployment-frontend:
+    needs: aws-tools-deployment-server
+    uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
     with:
       environment_name: tools
       tf_subcommand: apply
-      execute_flyway: true
-
     secrets:
       licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
-      dev_oidc_idir_idp_client_secret: "${{ secrets.DEV_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-      test_oidc_idir_idp_client_secret: "${{ secrets.TEST_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-      prod_oidc_idir_idp_client_secret: "${{ secrets.PROD_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-      dev_oidc_bceid_business_idp_client_secret: "${{ secrets.DEV_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-      test_oidc_bceid_business_idp_client_secret: "${{ secrets.TEST_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-      prod_oidc_bceid_business_idp_client_secret: "${{ secrets.PROD_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-      forest_client_api_api_key_test: "${{ secrets.FOREST_CLIENT_API_API_KEY_TEST }}"
-      dev_oidc_bcsc_idp_client_secret: "${{ secrets.DEV_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-      test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-      prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-      idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
-      gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
-      fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"

--- a/.github/workflows/lza_tools_deployment.yml
+++ b/.github/workflows/lza_tools_deployment.yml
@@ -4,31 +4,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  aws-tools-deployment-server:
-    uses: ./.github/workflows/lza_reusable_terraform_server.yml
-    with:
-      environment_name: tools
-      tf_subcommand: apply
-      execute_flyway: true
+  # aws-tools-deployment-server:
+  #   uses: ./.github/workflows/lza_reusable_terraform_server.yml
+  #   with:
+  #     environment_name: tools
+  #     tf_subcommand: apply
+  #     execute_flyway: true
 
-    secrets:
-      licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
-      dev_oidc_idir_idp_client_secret: "${{ secrets.DEV_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-      test_oidc_idir_idp_client_secret: "${{ secrets.TEST_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-      prod_oidc_idir_idp_client_secret: "${{ secrets.PROD_OIDC_IDIR_IDP_CLIENT_SECRET }}"
-      dev_oidc_bceid_business_idp_client_secret: "${{ secrets.DEV_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-      test_oidc_bceid_business_idp_client_secret: "${{ secrets.TEST_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-      prod_oidc_bceid_business_idp_client_secret: "${{ secrets.PROD_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
-      forest_client_api_api_key_test: "${{ secrets.FOREST_CLIENT_API_API_KEY_TEST }}"
-      dev_oidc_bcsc_idp_client_secret: "${{ secrets.DEV_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-      test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-      prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
-      idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
-      gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
-      fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
+  #   secrets:
+  #     licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
+  #     dev_oidc_idir_idp_client_secret: "${{ secrets.DEV_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+  #     test_oidc_idir_idp_client_secret: "${{ secrets.TEST_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+  #     prod_oidc_idir_idp_client_secret: "${{ secrets.PROD_OIDC_IDIR_IDP_CLIENT_SECRET }}"
+  #     dev_oidc_bceid_business_idp_client_secret: "${{ secrets.DEV_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+  #     test_oidc_bceid_business_idp_client_secret: "${{ secrets.TEST_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+  #     prod_oidc_bceid_business_idp_client_secret: "${{ secrets.PROD_OIDC_BCEID_BUSINESS_IDP_CLIENT_SECRET }}"
+  #     forest_client_api_api_key_test: "${{ secrets.FOREST_CLIENT_API_API_KEY_TEST }}"
+  #     dev_oidc_bcsc_idp_client_secret: "${{ secrets.DEV_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+  #     test_oidc_bcsc_idp_client_secret: "${{ secrets.TEST_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+  #     prod_oidc_bcsc_idp_client_secret: "${{ secrets.PROD_OIDC_BCSC_IDP_CLIENT_SECRET }}"
+  #     idim_proxy_api_api_key: "${{ secrets.IDIM_PROXY_API_API_KEY }}"
+  #     gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
+  #     fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
 
   aws-tools-deployment-frontend:
-    needs: aws-tools-deployment-server
+    # needs: aws-tools-deployment-server
     uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
     with:
       environment_name: tools

--- a/.github/workflows/lza_tools_deployment.yml
+++ b/.github/workflows/lza_tools_deployment.yml
@@ -27,11 +27,11 @@ jobs:
       gc_notify_email_api_key: "${{ secrets.GC_NOTIFY_EMAIL_API_KEY }}"
       fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
 
-  aws-tools-deployment-frontend:
-    needs: aws-tools-deployment-server
-    uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
-    with:
-      environment_name: tools
-      tf_subcommand: apply
-    secrets:
-      licenceplate: ${{ secrets.LZA_LICENCEPLATE}}
+  # aws-tools-deployment-frontend:
+  #   needs: aws-tools-deployment-server
+  #   uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
+  #   with:
+  #     environment_name: tools
+  #     tf_subcommand: apply
+  #   secrets:
+  #     licenceplate: ${{ secrets.LZA_LICENCEPLATE}}

--- a/.github/workflows/lza_tools_deployment.yml
+++ b/.github/workflows/lza_tools_deployment.yml
@@ -28,7 +28,7 @@ jobs:
   #     fam_update_user_info_api_key: "${{ secrets.FAM_UPDATE_USER_INFO_API_KEY }}"
 
   aws-tools-deployment-frontend:
-    needs: aws-tools-deployment-server
+    # needs: aws-tools-deployment-server
     uses: ./.github/workflows/lza_reusable_terraform_frontend.yml
     with:
       environment_name: tools

--- a/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
@@ -3,13 +3,14 @@ terraform {
 }
 
 locals {
+  region                  = "ca-central-1"
+
   # Terraform remote S3 config
   tf_remote_state_prefix  = "terraform-remote-state" # Do not change this, given by cloud.pathfinder.
   aws_license_plate       = get_env("licenceplate")
   target_env              = get_env("target_env")
   statefile_bucket_name   = "${local.tf_remote_state_prefix}-${local.aws_license_plate}-${local.target_env}" # Example @tools: "terraform-remote-state-sfha4x-tools"
   statefile_key          = "frontend.tfstate"
-  statelock_table_name    = "${local.tf_remote_state_prefix}-lock-${local.aws_license_plate}" # Example @tools: "terraform-remote-state-lock-sfha4x"
 }
 
 # Remote S3 state for Terraform.
@@ -21,9 +22,9 @@ terraform {
   backend "s3" {
     bucket         = "${local.statefile_bucket_name}"
     key            = "${local.statefile_key}"            # Path and name of the state file within the bucket
-    region         = "${local.region}"                       # AWS region where the bucket is located
-    dynamodb_table = "${local.statelock_table_name}"
+    region         = "${local.region}"                   # AWS region where the bucket is located
     encrypt        = true
+    use_lockfile   = true  # Enable native S3 locking
   }
 }
 EOF

--- a/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "..//..//..//..//lza-infrastructure//terraform//frontend"
+  source = "../../../../lza-infrastructure/terraform/frontend"
 }
 
 locals {

--- a/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "../../../lza-infrastructure/terraform/frontend"
+  source = "..//..//..//..//lza-infrastructure//terraform//frontend"
 }
 
 locals {

--- a/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
@@ -35,6 +35,7 @@ generate "tfvars" {
   if_exists         = "overwrite"
   disable_signature = true
   contents          = <<-EOF
+  licence_plate = "${ local.aws_license_plate }"
 EOF
 }
 

--- a/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/frontend/terragrunt.hcl
@@ -1,0 +1,60 @@
+terraform {
+  source = "../../../lza-infrastructure/terraform/frontend"
+}
+
+locals {
+  # Terraform remote S3 config
+  tf_remote_state_prefix  = "terraform-remote-state" # Do not change this, given by cloud.pathfinder.
+  aws_license_plate       = get_env("licenceplate")
+  target_env              = get_env("target_env")
+  statefile_bucket_name   = "${local.tf_remote_state_prefix}-${local.aws_license_plate}-${local.target_env}" # Example @tools: "terraform-remote-state-sfha4x-tools"
+  statefile_key          = "frontend.tfstate"
+  statelock_table_name    = "${local.tf_remote_state_prefix}-lock-${local.aws_license_plate}" # Example @tools: "terraform-remote-state-lock-sfha4x"
+}
+
+# Remote S3 state for Terraform.
+generate "remote_state" {
+  path      = "backend.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+terraform {
+  backend "s3" {
+    bucket         = "${local.statefile_bucket_name}"
+    key            = "${local.statefile_key}"            # Path and name of the state file within the bucket
+    region         = "${local.region}"                       # AWS region where the bucket is located
+    dynamodb_table = "${local.statelock_table_name}"
+    encrypt        = true
+  }
+}
+EOF
+}
+
+generate "tfvars" {
+  path              = "terragrunt.auto.tfvars"
+  if_exists         = "overwrite"
+  disable_signature = true
+  contents          = <<-EOF
+EOF
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+provider "aws" {
+  region  = "${local.region}"
+}
+
+# Additional provider configuration for us-east-1 region; resources can reference this as `aws.east`.
+# This is essential for adding WAF ACL rules as they are only available at us-east-1.
+# See AWS doc: https://docs.aws.amazon.com/pdfs/waf/latest/developerguide/waf-dg.pdf#how-aws-waf-works-resources
+#     on section: "Amazon CloudFront distributions"
+# Also refer to ticket (https://app.zenhub.com/workspaces/fsa-fingerprint-61f04f08304d3e001a4f2578/issues/gh/bcgov/nr-forests-access-management/725)
+#     for specific error ("CLOUDFRONT" is not valid)
+provider "aws" {
+  alias  = "east"
+  region = "us-east-1"
+}
+
+EOF
+}

--- a/lza-infrastructure/landing-zone/frontend/tools/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/frontend/tools/terragrunt.hcl
@@ -1,0 +1,14 @@
+include {
+  path = find_in_parent_folders()
+}
+
+generate "tools_tfvars" {
+  path              = "tools.auto.tfvars"
+  if_exists         = "overwrite"
+  disable_signature = true
+  contents          = <<-EOF
+  target_env = "tools"
+  # cloudfront_vanity_domain = "fam-tools.nrs.gov.bc.ca"
+  # cloudfront_certificate_arn = "arn:aws:acm:us-east-1:377481750915:certificate/1c653a26-ad35-4e00-8c1b-3c159948d09f"
+EOF
+}

--- a/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
@@ -34,12 +34,14 @@ generate "tools_tfvars" {
   front_end_redirect_path = "https://d3dndacxwfefe0.cloudfront.net"
   fam_callback_urls = [
     "https://fam-tools.nrs.gov.bc.ca/authCallback",
+    "https://d3dndacxwfefe0.cloudfront.net/authCallback"
     "http://localhost:5173/authCallback",
     "http://localhost:8000/docs/oauth2-redirect",
     "http://localhost:8001/docs/oauth2-redirect"
   ]
   fam_logout_urls = [
     "${local.common_vars.inputs.idp_logout_chain_test_url}https://fam-tools.nrs.gov.bc.ca",
+    "${local.common_vars.inputs.idp_logout_chain_test_url}https://d3dndacxwfefe0.cloudfront.net",
     "${local.common_vars.inputs.idp_logout_chain_test_url}http://localhost:5173"
   ]
   fam_console_idp_name = "TEST-IDIR"

--- a/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
@@ -34,7 +34,7 @@ generate "tools_tfvars" {
   front_end_redirect_path = "https://d3dndacxwfefe0.cloudfront.net"
   fam_callback_urls = [
     "https://fam-tools.nrs.gov.bc.ca/authCallback",
-    "https://d3dndacxwfefe0.cloudfront.net/authCallback"
+    "https://d3dndacxwfefe0.cloudfront.net/authCallback",
     "http://localhost:5173/authCallback",
     "http://localhost:8000/docs/oauth2-redirect",
     "http://localhost:8001/docs/oauth2-redirect"

--- a/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
@@ -30,7 +30,8 @@ generate "tools_tfvars" {
     prod = "${local.common_vars.inputs.idp_logout_chain_prod_url}"
     tools = "${local.common_vars.inputs.idp_logout_chain_tools_url}"
   }
-  front_end_redirect_path = "https://fam-tools.nrs.gov.bc.ca"
+  # front_end_redirect_path = "https://fam-tools.nrs.gov.bc.ca"
+  front_end_redirect_path = "d3dndacxwfefe0.cloudfront.net"
   fam_callback_urls = [
     "https://fam-tools.nrs.gov.bc.ca/authCallback",
     "http://localhost:5173/authCallback",

--- a/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
+++ b/lza-infrastructure/landing-zone/server/tools/terragrunt.hcl
@@ -31,7 +31,7 @@ generate "tools_tfvars" {
     tools = "${local.common_vars.inputs.idp_logout_chain_tools_url}"
   }
   # front_end_redirect_path = "https://fam-tools.nrs.gov.bc.ca"
-  front_end_redirect_path = "d3dndacxwfefe0.cloudfront.net"
+  front_end_redirect_path = "https://d3dndacxwfefe0.cloudfront.net"
   fam_callback_urls = [
     "https://fam-tools.nrs.gov.bc.ca/authCallback",
     "http://localhost:5173/authCallback",

--- a/lza-infrastructure/terraform/frontend/cloudfront.tf
+++ b/lza-infrastructure/terraform/frontend/cloudfront.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_policy" "web_distribution" {
 }
 
 resource "aws_cloudfront_distribution" "web_distribution" {
-  aliases             = ["${var.cloudfront_vanity_domain}"]
+  # aliases             = ["${var.cloudfront_vanity_domain}"]
   enabled             = true
   is_ipv6_enabled     = true
   wait_for_deployment = false

--- a/lza-infrastructure/terraform/frontend/cloudfront.tf
+++ b/lza-infrastructure/terraform/frontend/cloudfront.tf
@@ -1,5 +1,5 @@
 locals {
-  flyway_scripts_bucket_name = "fam-cloudfront-bucket-${var.target_env}"
+  flyway_scripts_bucket_name = "fam-cloudfront-bucket-${var.licence_plate}-${var.target_env}"
 }
 
 resource "aws_s3_bucket" "web_distribution" {

--- a/lza-infrastructure/terraform/frontend/cloudfront.tf
+++ b/lza-infrastructure/terraform/frontend/cloudfront.tf
@@ -1,0 +1,124 @@
+locals {
+  flyway_scripts_bucket_name = "fam-cloudfront-bucket-${var.target_env}"
+}
+
+resource "aws_s3_bucket" "web_distribution" {
+  bucket = local.flyway_scripts_bucket_name
+  #acl    = "public-read"
+
+}
+
+resource "aws_cloudfront_origin_access_identity" "web_distribution" {
+}
+
+data "aws_iam_policy_document" "web_distribution" {
+  statement {
+    actions = ["s3:GetObject"]
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.web_distribution.iam_arn}"]
+    }
+    resources = ["${aws_s3_bucket.web_distribution.arn}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "web_distribution" {
+  bucket = aws_s3_bucket.web_distribution.id
+  policy = data.aws_iam_policy_document.web_distribution.json
+}
+
+resource "aws_cloudfront_distribution" "web_distribution" {
+  aliases             = ["${var.cloudfront_vanity_domain}"]
+  enabled             = true
+  is_ipv6_enabled     = true
+  wait_for_deployment = false
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100"
+  web_acl_id          = "${aws_wafv2_web_acl.fam_waf_cloudfront.arn}"
+
+  viewer_certificate {
+    # acm_certificate_arn = "${var.cloudfront_certificate_arn}"
+    # ssl_support_method = "sni-only"
+    # minimum_protocol_version = "TLSv1.2_2021"
+
+    cloudfront_default_certificate = true  # TODO: remove this after certificate is issued and in place and adjust above. Use AWS default for now.
+  }
+
+  origin {
+    domain_name = aws_s3_bucket.web_distribution.bucket_regional_domain_name
+    origin_id   = "web_distribution_origin"
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.web_distribution.cloudfront_access_identity_path
+    }
+  }
+
+  # Required for SPA application to redirect requests to deep links to root, which loads index.html, which loads the Vue app
+  # and then the Vue router properly resolves the deep link.
+  custom_error_response {
+    error_code = 403
+    response_code = 200
+    response_page_path = "/"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "web_distribution_origin"
+
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "none"
+      }
+      headers = ["Origin"]
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 300
+    max_ttl                = 86400
+
+
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["CA", "US"]
+    }
+  }
+}
+
+locals {
+  src_dir = "./dist/"
+  content_type_map = {
+    html = "text/html",
+    ico  = "image/x-icon",
+    js   = "application/javascript",
+    json = "application/json",
+    svg  = "image/svg+xml",
+    ttf  = "font/ttf",
+    txt  = "text/txt",
+    css  = "text/css",
+    pdf  = "application/pdf"
+  }
+  ignore_files = [".terragrunt-source-manifest","assets/.terragrunt-source-manifest","files/.terragrunt-source-manifest"]
+  files_raw = fileset(local.src_dir, "**")
+  files = toset([
+    for jsFile in local.files_raw:
+      jsFile if !contains(local.ignore_files, jsFile)
+  ])
+}
+
+resource "aws_s3_bucket_object" "site_files" {
+  # for_each = fileset(local.src_dir, "**")
+  for_each = local.files
+
+  # Create an object from each
+  bucket = aws_s3_bucket.web_distribution.id
+  key    = each.value
+  source = "${local.src_dir}/${each.value}"
+  etag = filemd5("${local.src_dir}/${each.value}")
+
+  content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9_]+)$", each.value).extension, "application/octet-stream")
+}

--- a/lza-infrastructure/terraform/frontend/outputs.tf
+++ b/lza-infrastructure/terraform/frontend/outputs.tf
@@ -1,0 +1,4 @@
+output "cf_domain_name" {
+  value       = try(aws_cloudfront_distribution.web_distribution.domain_name, "")
+  description = "Domain name corresponding to the distribution"
+}

--- a/lza-infrastructure/terraform/frontend/variables_provided.tf
+++ b/lza-infrastructure/terraform/frontend/variables_provided.tf
@@ -3,12 +3,12 @@ variable "target_env" {
   type        = string
 }
 
-variable "cloudfront_vanity_domain" {
-  description = "Alternate vanity domain to use for cloudfront distribution for frontend"
-  type = string
-}
+# variable "cloudfront_vanity_domain" {
+#   description = "Alternate vanity domain to use for cloudfront distribution for frontend"
+#   type = string
+# }
 
-variable "cloudfront_certificate_arn" {
-  description = "ARN for certificate to use in cloudfront"
-  type = string
-}
+# variable "cloudfront_certificate_arn" {
+#   description = "ARN for certificate to use in cloudfront"
+#   type = string
+# }

--- a/lza-infrastructure/terraform/frontend/variables_provided.tf
+++ b/lza-infrastructure/terraform/frontend/variables_provided.tf
@@ -1,0 +1,14 @@
+variable "target_env" {
+  description = "AWS workload account env"
+  type        = string
+}
+
+variable "cloudfront_vanity_domain" {
+  description = "Alternate vanity domain to use for cloudfront distribution for frontend"
+  type = string
+}
+
+variable "cloudfront_certificate_arn" {
+  description = "ARN for certificate to use in cloudfront"
+  type = string
+}

--- a/lza-infrastructure/terraform/frontend/variables_provided.tf
+++ b/lza-infrastructure/terraform/frontend/variables_provided.tf
@@ -3,6 +3,11 @@ variable "target_env" {
   type        = string
 }
 
+variable "licence_plate" {
+  description = "AWS project license plate"
+  type        = string
+}
+
 # variable "cloudfront_vanity_domain" {
 #   description = "Alternate vanity domain to use for cloudfront distribution for frontend"
 #   type = string

--- a/lza-infrastructure/terraform/frontend/version.tf
+++ b/lza-infrastructure/terraform/frontend/version.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.99.1"
+    }
+  }
+}

--- a/lza-infrastructure/terraform/frontend/waf-firewall-cloudfront.tf
+++ b/lza-infrastructure/terraform/frontend/waf-firewall-cloudfront.tf
@@ -1,0 +1,128 @@
+locals {
+  fam_waf_cloudfront_resource_name = "fam-${var.target_env}-waf-cloudfront"
+}
+
+# CloudFront WAF ACL
+resource "aws_wafv2_web_acl" "fam_waf_cloudfront" {
+    name        = "${local.fam_waf_cloudfront_resource_name}"
+    description = "CloudFront WAF Rules"
+    scope       = "CLOUDFRONT"
+    provider    = aws.east # Cloudfront ACL has to be created in this region.
+
+    default_action {
+        allow {}
+    }
+
+
+    ## AWS Managed rules below.
+    rule {
+        name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+        priority = 0
+
+        override_action {
+            none {}
+        }
+        statement {
+            managed_rule_group_statement {
+                vendor_name = "AWS"
+                name        = "AWSManagedRulesAmazonIpReputationList"
+            }
+        }
+        visibility_config {
+            cloudwatch_metrics_enabled = true
+            metric_name                = "${local.fam_waf_cloudfront_resource_name}-AWSManagedRulesAmazonIpReputationList"
+            sampled_requests_enabled   = true
+        }
+    }
+
+    rule {
+        name     = "AWS-AWSManagedRulesCommonRuleSet"
+        priority = 1
+
+        override_action {
+            none {}
+        }
+        statement {
+            managed_rule_group_statement {
+                vendor_name = "AWS"
+                name        = "AWSManagedRulesCommonRuleSet"
+            }
+        }
+        visibility_config {
+            cloudwatch_metrics_enabled = true
+            metric_name                = "${local.fam_waf_cloudfront_resource_name}-AWSManagedRulesCommonRuleSet"
+            sampled_requests_enabled   = true
+        }
+    }
+
+    rule {
+        name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+        priority = 2
+
+        override_action {
+            none {}
+        }
+        statement {
+            managed_rule_group_statement {
+                vendor_name = "AWS"
+                name        = "AWSManagedRulesKnownBadInputsRuleSet"
+            }
+        }
+        visibility_config {
+            cloudwatch_metrics_enabled = true
+            metric_name                = "${local.fam_waf_cloudfront_resource_name}-AWSManagedRulesKnownBadInputsRuleSet"
+            sampled_requests_enabled   = true
+        }
+    }
+
+    rule {
+        name     = "AWS-AWSManagedRulesLinuxRuleSet"
+        priority = 3
+
+        override_action {
+            none {}
+        }
+        statement {
+            managed_rule_group_statement {
+                vendor_name = "AWS"
+                name        = "AWSManagedRulesLinuxRuleSet"
+            }
+        }
+        visibility_config {
+            cloudwatch_metrics_enabled = true
+            metric_name                = "${local.fam_waf_cloudfront_resource_name}-AWSManagedRulesLinuxRuleSet"
+            sampled_requests_enabled   = true
+        }
+    }
+
+    rule {
+        name     = "AWS-AWSManagedRulesSQLiRuleSet"
+        priority = 4
+
+        override_action {
+            none {}
+        }
+        statement {
+            managed_rule_group_statement {
+                vendor_name = "AWS"
+                name        = "AWSManagedRulesSQLiRuleSet"
+            }
+        }
+        visibility_config {
+            cloudwatch_metrics_enabled = true
+            metric_name                = "${local.fam_waf_cloudfront_resource_name}-AWSManagedRulesSQLiRuleSet"
+            sampled_requests_enabled   = true
+        }
+    }
+
+    tags = {
+        env = "${var.target_env}"
+        managed-by = "terraform"
+    }
+
+    visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${local.fam_waf_cloudfront_resource_name}"
+        sampled_requests_enabled   = true
+    }
+}

--- a/lza-infrastructure/terraform/server/outputs.tf
+++ b/lza-infrastructure/terraform/server/outputs.tf
@@ -35,10 +35,10 @@ output "frontend_logout_chain_url" {
   value = var.target_env == "prod" ? var.cognito_app_client_logout_chain_url.prod : var.cognito_app_client_logout_chain_url.test
 }
 
-# output "front_end_redirect_base_url" {
-#   description = "Frontend CloudFront base url"
-#   value = var.front_end_redirect_path
-# }
+output "front_end_redirect_base_url" {
+  description = "Frontend CloudFront base url"
+  value = var.front_end_redirect_path
+}
 
 output "target_env" {
   description = "dev, test, or prod in AWS"


### PR DESCRIPTION
A Cloudfront portion for LZA to be merged to feature branch.
- added `lza_reusable_terraform_frontend.yml`
- added `aws-tools-deployment-frontend` step to `lza_tools_deployment.yml`
- added `lza-infrastructure/landing-zone/frontend/terragrunt.hcl` and `lza-infrastructure/landing-zone/frontend/tools/terragrunt.hcl` for frontend Terraform state management and Terraform variables.
- added `lza-infrastructure/terraform/frontend/cloudfront.tf` for distribution.
Note:  Due to currently we don't have vanity url yet for Cloudfront at LZA
   * cloudfront_vanity_domain related variables are commented out.
   * `front_end_redirect_path` is set to AWS default (hardcoded)
   * `viewer_certificate` and `aliase` is also commented out.
- added lza-infrastructure/landing-zone/server/tools/terragrunt.hcl: configure temporary aws default domain callback url for Cognito fam client.
- added lza-infrastructure/terraform/frontend/outputs.tf: for output Cloudfront domain name.
- added lza-infrastructure/terraform/frontend/waf-firewall-cloudfront.tf: Cloudfront WAF.