### PR TITLE
fix: #1993 Viewer Request Lambda for Handling SPA Web Origin 403

### DIFF
--- a/lza-infrastructure/terraform/frontend/cloudfront.tf
+++ b/lza-infrastructure/terraform/frontend/cloudfront.tf
@@ -2,6 +2,8 @@ locals {
   flyway_scripts_bucket_name = "fam-cloudfront-bucket-${var.licence_plate}-${var.target_env}"
   web_distribution_origin_id = "web_distribution_origin"
   consumer_fam_api_origin_id = "consumer_fam_api_gateway_origin"
+  api_origin_behavior_path_pattern = "/api"
+  api_gateway_stage_name = "v1"
 }
 
 resource "aws_s3_bucket" "web_distribution" {
@@ -120,7 +122,7 @@ resource "aws_cloudfront_distribution" "web_distribution" {
   */
   ordered_cache_behavior {
     # maps request URL path "/api/..." to API Gateway origin
-    path_pattern           = "/api/*"
+    path_pattern           = "${local.api_origin_behavior_path_pattern}/*"
     target_origin_id       = local.consumer_fam_api_origin_id
 
     viewer_protocol_policy = "https-only"
@@ -177,7 +179,7 @@ resource "aws_cloudfront_function" "fam_web_viewer_request_function" {
       var headers = request.headers;
 
       // Skip API requests
-      if (uri.startsWith('/api/')) {
+      if (uri.startsWith('${local.api_origin_behavior_path_pattern}/')) {
         return request;
       }
 
@@ -217,8 +219,8 @@ function handler(event) {
   request.headers["x-request-id"] = { value: `$${Math.random().toString(36).substring(2)}-$${new Date().toISOString()}` };
 
   // Rewrite /api/* to /v1/*
-  if (request.uri.startsWith("/api/")) {
-      request.uri = request.uri.replace("/api/", "/v1/");
+  if (request.uri.startsWith("${local.api_origin_behavior_path_pattern}/")) {
+      request.uri = request.uri.replace("${local.api_origin_behavior_path_pattern}/", "/${local.api_gateway_stage_name}/");
   }
 
   return request;


### PR DESCRIPTION
The removal of **403 Error Page** handling at Terraform previously for CloudFront distribution has caused FAM frontend SPA Vue app not able to load with 403 error after user login. 
Due to the addition of the new API Gateway origin for consumer api the 403 error should return to the client app correctly, so
the removal of 403 Error Page was needed.
To recover back the 403 error handing for S3 origin for frontend to load properly, this PR uses different (better) way of handling S3 origin request (such as /authCallback after IDP redirect back to users' browser) by conditionally rewrite viewer's request before the matching origin receive the request, so the frontend will load index.html properly after user login.

* Terraform: add AWS CloudFront **Viewer Request function** to handle S3 origin request to properly load index.html.
* Terraform: link the new viewer request function to S3 web origin.