### PR TITLE
chore(ci): update routes for nr-results-exam

### DIFF
--- a/lza-infrastructure/terraform/server/oidc_clients_results_exam.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_results_exam.tf
@@ -71,7 +71,6 @@ resource "aws_cognito_user_pool_client" "test_results_exam_oidc_client" {
     id_token      = "minutes"
     refresh_token = "hours"
   }
-
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
   write_attributes = var.minimum_oidc_attribute_list
 }
@@ -84,11 +83,11 @@ resource "aws_cognito_user_pool_client" "prod_results_exam_oidc_client" {
   callback_urls                                 = [
     var.oidc_sso_playground_url,
     "https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca/dashboard",
-    "https://results-exam.apps.silver.devops.gov.bc.ca/dashboard",
+    "https://results-exam.apps.silver.devops.gov.bc.ca/dashboard"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.prod}https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca/"
+    "${var.cognito_app_client_logout_chain_url.prod}https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca/",
     "${var.cognito_app_client_logout_chain_url.prod}https://results-exam.apps.silver.devops.gov.bc.ca/"
   ]
   enable_propagate_additional_user_context_data = "false"


### PR DESCRIPTION
For `bcgov/nr-results-exam`.
- Removes `-frontend` from PR and TEST URLs
- Shortens PROD URL
- Leaves previous PROD URL (temporarily)

UPDATE: Revised to add new PROD pattern, but not remove previous yet.  Thanks @ianliuwk1019!