### PR TITLE
fix: # Rename APT3 APP Description.

### DIFF
--- a/server/flyway/sql/V77__update_apt3_app_description.sql
+++ b/server/flyway/sql/V77__update_apt3_app_description.sql
@@ -1,0 +1,7 @@
+-- Update the application description for APT3
+-- APT3 is not being used. Previously was created for APT modernization efforts, but the team reuse APT2 instead.
+
+UPDATE app_fam.fam_application
+SET application_description =
+    REGEXP_REPLACE(application_description, 'Apportionment', 'Apportionment 3') || ' - Retired'
+WHERE application_name LIKE 'APT3%';


### PR DESCRIPTION
ref: #2050 
This is to make APT3 distinguishable with APT2 as currently they have the same application description.
Also APT3 is not being used and this will mark this app 'retired'.
The team doing the APT modernization is reusing the APT2.

Later will have a ticket to clean up APT3 from database.
