### PR TITLE
fix: Added the pub redirect urls for APT2, REPT and ISP

### DIFF
--- a/lza-infrastructure/terraform/server/oidc_clients_apt2.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_apt2.tf
@@ -7,15 +7,19 @@ resource "aws_cognito_user_pool_client" "dev_apt_oidc_client" {
     var.oidc_sso_playground_url,
     "http://localhost:8080/apt2/callback",
     "https://dlvrapps.nrs.gov.bc.ca/int/apt2/callback",
+    "https://dlvrapps.nrs.gov.bc.ca/pub/apt2/callback",
     "http://localhost:3000/",
-    "https://dlvrapps.nrs.gov.bc.ca/int/apt2"
+    "https://dlvrapps.nrs.gov.bc.ca/int/apt2",
+    "https://dlvrapps.nrs.gov.bc.ca/pub/apt2"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:8080/",
     "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/apt2",
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/pub/apt2",
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000/logout",
-    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/apt2/logout"
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/apt2/logout",
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/pub/apt2/logout"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -48,12 +52,15 @@ resource "aws_cognito_user_pool_client" "test_apt_oidc_client" {
       var.oidc_sso_playground_url,
       "http://localhost:8080/apt2/callback",
       "https://testapps.nrs.gov.bc.ca/int/apt2/callback",
-      "https://dlvrapps.nrs.gov.bc.ca/int/apt2/callback"
+      "https://testapps.nrs.gov.bc.ca/pub/apt2/callback",
+      "https://dlvrapps.nrs.gov.bc.ca/int/apt2/callback",
+      "https://dlvrapps.nrs.gov.bc.ca/pub/apt2/callback"
     ]
   logout_urls                                   = [
       var.oidc_sso_playground_url,
       "${var.cognito_app_client_logout_chain_url.test}http://localhost:8080/",
-      "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/int/apt2"
+      "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/int/apt2",
+      "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/pub/apt2"
     ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -84,11 +91,13 @@ resource "aws_cognito_user_pool_client" "prod_apt_oidc_client" {
   allowed_oauth_scopes                          = ["openid", "profile", "email"]
   callback_urls                                 = [
     var.oidc_sso_playground_url,
-    "https://apps.nrs.gov.bc.ca/int/apt2/callback"
+    "https://apps.nrs.gov.bc.ca/int/apt2/callback",
+    "https://apps.nrs.gov.bc.ca/pub/apt2/callback"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/int/apt2"
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/int/apt2",
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/pub/apt2"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"

--- a/lza-infrastructure/terraform/server/oidc_clients_isp.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_isp.tf
@@ -6,12 +6,14 @@ resource "aws_cognito_user_pool_client" "dev_isp_oidc_client" {
   callback_urls                                 = [
     var.oidc_sso_playground_url,
     "http://localhost:3000/",
-    "https://dlvrapps.nrs.gov.bc.ca/int/isp/callback"
+    "https://dlvrapps.nrs.gov.bc.ca/int/isp/callback",
+    "https://dlvrapps.nrs.gov.bc.ca/pub/isp/callback"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000",
-    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/isp"
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/isp",
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/pub/isp"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -43,12 +45,14 @@ resource "aws_cognito_user_pool_client" "test_isp_oidc_client" {
   callback_urls                                 = [
     var.oidc_sso_playground_url,
     "http://localhost:8080/isp/callback",
-    "https://testapps.nrs.gov.bc.ca/int/isp/callback"
+    "https://testapps.nrs.gov.bc.ca/int/isp/callback",
+    "https://testapps.nrs.gov.bc.ca/pub/isp/callback"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.test}http://localhost:8000",
-    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/int/isp"
+    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/int/isp",
+    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/pub/isp"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -79,11 +83,13 @@ resource "aws_cognito_user_pool_client" "prod_isp_oidc_client" {
   allowed_oauth_scopes                          = ["openid", "profile", "email"]
   callback_urls                                 = [
     var.oidc_sso_playground_url,
-    "https://apps.nrs.gov.bc.ca/int/isp/callback"
+    "https://apps.nrs.gov.bc.ca/int/isp/callback",
+    "https://apps.nrs.gov.bc.ca/pub/isp/callback"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/int/isp"
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/int/isp",
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/pub/isp"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"

--- a/lza-infrastructure/terraform/server/oidc_clients_rept.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_rept.tf
@@ -7,17 +7,23 @@ resource "aws_cognito_user_pool_client" "dev_rept_oidc_client" {
     var.oidc_sso_playground_url,
     "http://localhost:3000/dashboard",
     "http://localhost:3000/int/rept/dashboard",
+    "http://localhost:3000/pub/rept/dashboard",
     "http://localhost:8080/dashboard",
     "http://localhost:8080/int/rept/dashboard",
-    "https://dlvrapps.nrs.gov.bc.ca/int/rept/dashboard"
+    "http://localhost:8080/pub/rept/dashboard",
+    "https://dlvrapps.nrs.gov.bc.ca/int/rept/dashboard",
+    "https://dlvrapps.nrs.gov.bc.ca/pub/rept/dashboard"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000",
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000/int/rept",
+    "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000/pub/rept",
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:8080",
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:8080/int/rept",
-    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/rept"
+    "${var.cognito_app_client_logout_chain_url.dev}http://localhost:8080/pub/rept",
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/int/rept",
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/pub/rept"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -50,13 +56,17 @@ resource "aws_cognito_user_pool_client" "test_rept_oidc_client" {
     var.oidc_sso_playground_url,
     "http://localhost:3000/dashboard",
     "http://localhost:3000/int/rept/dashboard",
-    "https://testapps.nrs.gov.bc.ca/int/rept/dashboard"
+    "http://localhost:3000/pub/rept/dashboard",
+    "https://testapps.nrs.gov.bc.ca/int/rept/dashboard",
+    "https://testapps.nrs.gov.bc.ca/pub/rept/dashboard"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000",
     "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000/int/rept",
-    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/int/rept"
+    "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000/pub/rept",
+    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/int/rept",
+    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/pub/rept"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -87,11 +97,13 @@ resource "aws_cognito_user_pool_client" "prod_rept_oidc_client" {
   allowed_oauth_scopes                          = ["openid", "profile", "email"]
   callback_urls                                 = [
     var.oidc_sso_playground_url,
-    "https://apps.nrs.gov.bc.ca/int/rept/dashboard"
+    "https://apps.nrs.gov.bc.ca/int/rept/dashboard",
+    "https://apps.nrs.gov.bc.ca/pub/rept/dashboard"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/int/rept"
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/int/rept",
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/pub/rept"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"


### PR DESCRIPTION
This PR adds the pub prefix URLs for the APT2, REPT and the ISP legacy applications, being mordernised. Linked to the issue: #2085 .
