### PR TITLE
fix: add PR urls to waste plus test environment 

### DIFF
--- a/lza-infrastructure/terraform/server/oidc_clients_waste_plus.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_waste_plus.tf
@@ -53,8 +53,8 @@ resource "aws_cognito_user_pool_client" "test_waste_plus_oidc_client" {
       "http://127.0.0.1:3000/dashboard",
       "https://nr-waste-plus-test-frontend.apps.silver.devops.gov.bc.ca/dashboard",
       "https://wasteplus-tst.nrs.gov.bc.ca/dashboard",
-      [for i in range("${var.dev_pr_url_count}") : "https://nr-waste-plus-${i}-frontend.apps.silver.devops.gov.bc.ca/dashboard"]
-    ]
+    ],
+    [for i in range("${var.dev_pr_url_count}") : "https://nr-waste-plus-${i}-frontend.apps.silver.devops.gov.bc.ca/dashboard"]
   )
   logout_urls                                   = concat(
     [
@@ -62,9 +62,9 @@ resource "aws_cognito_user_pool_client" "test_waste_plus_oidc_client" {
       "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000",
       "${var.cognito_app_client_logout_chain_url.test}http://127.0.0.1:3000",
       "${var.cognito_app_client_logout_chain_url.test}https://nr-waste-plus-test-frontend.apps.silver.devops.gov.bc.ca",
-      "${var.cognito_app_client_logout_chain_url.test}https://wasteplus-tst.nrs.gov.bc.ca",
-      [for i in range("${var.dev_pr_url_count}") : "${var.cognito_app_client_logout_chain_url.dev}https://nr-waste-plus-${i}-frontend.apps.silver.devops.gov.bc.ca"]
-    ]
+      "${var.cognito_app_client_logout_chain_url.test}https://wasteplus-tst.nrs.gov.bc.ca"
+    ],
+    [for i in range("${var.dev_pr_url_count}") : "${var.cognito_app_client_logout_chain_url.dev}https://nr-waste-plus-${i}-frontend.apps.silver.devops.gov.bc.ca"]
   )
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"


### PR DESCRIPTION
As requested by @paulushcgcj 

Updated config for Waste Plus so they can use PR urls (e.g. `https://nr-waste-plus-2-frontend.apps.silver.devops.gov.bc.ca/`) in their test environment, so that a user can log in on a PR deployment with IDIR test or BCeID test account. 