### PR TITLE
fix: Restrict nr-theme Version Bump

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
             "name": "fam-frontend",
             "version": "0.0.0",
             "dependencies": {
-                "@bcgov-nr/nr-theme": "^1.8.9",
+                "@bcgov-nr/nr-theme": "~1.8.9",
                 "@carbon/icons-vue": "^10.99.1",
                 "@carbon/themes": "^11.43.0",
                 "@carbon/type": "^11.31.0",
@@ -1725,9 +1725,9 @@
             }
         },
         "node_modules/@bcgov-nr/nr-theme": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@bcgov-nr/nr-theme/-/nr-theme-1.9.1.tgz",
-            "integrity": "sha512-Nr0gUmAA5IsHiOzulLZAnukZsvdbkv/FtVxYvM7PjGJkS7E54RqxGvo7xAIghiBk0NyPhVrcuEKo3wPfRMApjA==",
+            "version": "1.8.9",
+            "resolved": "https://registry.npmjs.org/@bcgov-nr/nr-theme/-/nr-theme-1.8.9.tgz",
+            "integrity": "sha512-NqljotGT6q2kVSBj6CLExkPxLc8w2ChiaRW+mQcHfgBG3RJrKk8HhwUSIuK6I8uWYwWmIyArNuA+NwS8/goTTA==",
             "license": "ISC"
         },
         "node_modules/@bcoe/v8-coverage": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
         "test-coverage": "vitest run --coverage"
     },
     "dependencies": {
-        "@bcgov-nr/nr-theme": "^1.8.9",
+        "@bcgov-nr/nr-theme": "~1.8.9",
         "@carbon/icons-vue": "^10.99.1",
         "@carbon/themes": "^11.43.0",
         "@carbon/type": "^11.31.0",


### PR DESCRIPTION
- Temporarily restrict nr-them version bump to higher so it does not mess with FAM font weight. A fix will be on this ticket: https://github.com/bcgov/nr-forests-access-management/issues/2137