### PR TITLE
fix: #2173 Font Weight From nr-theme Package

### DIFF
--- a/frontend/src/assets/styles/styles.scss
+++ b/frontend/src/assets/styles/styles.scss
@@ -19,6 +19,7 @@
     This file contains global styles and overrides for PrimeVue components.
     As of today, the package uses "@bcgov-nr/nr-theme": "~1.8.9".
     The nr-theme package after and including version 1.9.0 introduces "BC Sans 2.0" and some other changes.
+    Ref: https://github.com/bcgov/nr-theme/issues/185?reload=1
     That will result in visual look and feel differences in FAM on fonts and will require to adjust
     font-weight and font-size globally at "body { }" selector below or specifically in components/pages
     to match the look and feel of the existing FAM. For example, even with "font-weight: normal" at both

--- a/frontend/src/assets/styles/styles.scss
+++ b/frontend/src/assets/styles/styles.scss
@@ -13,6 +13,18 @@
     --primevue-striped-row-color: rgba(0, 0, 0, 0.05);
 }
 
+/*
+    Note:
+    FAM uses @bcgov-nr/nr-theme for design tokens and PrimeVue for UI components.
+    This file contains global styles and overrides for PrimeVue components.
+    As of today, the package uses "@bcgov-nr/nr-theme": "~1.8.9".
+    The nr-theme package after and including version 1.9.0 introduces "BC Sans 2.0" and some other changes.
+    That will result in visual look and feel differences in FAM on fonts and will require to adjust
+    font-weight and font-size globally at "body { }" selector below or specifically in components/pages
+    to match the look and feel of the existing FAM. For example, even with "font-weight: normal" at both
+    BC Sans and BC Sans 2.0, the font-weight looks different.
+    We currently decided to keep using ~1.8.9 version of nr-theme package.
+*/
 // Global styles
 body {
     padding: 0;

--- a/frontend/src/assets/styles/styles.scss
+++ b/frontend/src/assets/styles/styles.scss
@@ -16,7 +16,7 @@
 /*
     Note:
     FAM uses @bcgov-nr/nr-theme for design tokens and PrimeVue for UI components.
-    This file contains global styles and overrides for PrimeVue components.
+    This @bcgov-nr/nr-theme package contains global styles and overrides for PrimeVue components.
     As of today, the package uses "@bcgov-nr/nr-theme": "~1.8.9".
     The nr-theme package after and including version 1.9.0 introduces "BC Sans 2.0" and some other changes.
     Ref: https://github.com/bcgov/nr-theme/issues/185?reload=1


### PR DESCRIPTION
- For font fading issue: team decided to keep using nr-them package v1.8.9 than update to v1.9.1.
- A note is added to `style.scss` close to where developer can easily notice it.