### PR TITLE
feat: #2140 Onboard FSPTS App to FAM

### DIFF
--- a/.github/workflows/reusable_data_model_gen.yml
+++ b/.github/workflows/reusable_data_model_gen.yml
@@ -99,6 +99,9 @@ jobs:
           FLYWAY_PLACEHOLDERS_client_id_dev_scs_oidc_client: flywayplaceholder
           FLYWAY_PLACEHOLDERS_client_id_test_scs_oidc_client: flywayplaceholder
           FLYWAY_PLACEHOLDERS_client_id_prod_scs_oidc_client: flywayplaceholder
+          FLYWAY_PLACEHOLDERS_client_id_dev_fspts_oidc_client: flywayplaceholder
+          FLYWAY_PLACEHOLDERS_client_id_test_fspts_oidc_client: flywayplaceholder
+          FLYWAY_PLACEHOLDERS_client_id_prod_fspts_oidc_client: flywayplaceholder
         with:
           args: info migrate info
 

--- a/docker-base-services.yml
+++ b/docker-base-services.yml
@@ -75,5 +75,8 @@ services:
             - FLYWAY_PLACEHOLDERS_client_id_dev_scs_oidc_client="flywayplaceholder"
             - FLYWAY_PLACEHOLDERS_client_id_test_scs_oidc_client="flywayplaceholder"
             - FLYWAY_PLACEHOLDERS_client_id_prod_scs_oidc_client="flywayplaceholder"
+            - FLYWAY_PLACEHOLDERS_client_id_dev_fspts_oidc_client="flywayplaceholder"
+            - FLYWAY_PLACEHOLDERS_client_id_test_fspts_oidc_client="flywayplaceholder"
+            - FLYWAY_PLACEHOLDERS_client_id_prod_fspts_oidc_client="flywayplaceholder"
         networks:
             - fam

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       service: fam-database
     container_name: fam-postgres
     ports:
-      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
+      - "${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}"
 
   fam-flyway:
     extends:
       file: docker-base-services.yml
       service: fam-flyway
     environment:
-      - FLYWAY_URL=jdbc:postgresql://fam-postgres:${POSTGRES_PORT}/fam
+      - FLYWAY_URL=jdbc:postgresql://fam-postgres:${POSTGRES_PORT:-5432}/fam
     depends_on:
       fam-database:
         condition: service_healthy

--- a/lza-infrastructure/terraform/server/flyway.tf
+++ b/lza-infrastructure/terraform/server/flyway.tf
@@ -284,7 +284,10 @@ data "aws_lambda_invocation" "invoke_flyway_migration" {
           "client_id_prod_isp_oidc_client" : "${aws_cognito_user_pool_client.prod_isp_oidc_client.id}",
           "client_id_dev_scs_oidc_client" : "${aws_cognito_user_pool_client.dev_scs_oidc_client.id}",
           "client_id_test_scs_oidc_client" : "${aws_cognito_user_pool_client.test_scs_oidc_client.id}",
-          "client_id_prod_scs_oidc_client" : "${aws_cognito_user_pool_client.prod_scs_oidc_client.id}"
+          "client_id_prod_scs_oidc_client" : "${aws_cognito_user_pool_client.prod_scs_oidc_client.id}",
+          "client_id_dev_fspts_oidc_client" : "${aws_cognito_user_pool_client.dev_fspts_oidc_client.id}",
+          "client_id_test_fspts_oidc_client" : "${aws_cognito_user_pool_client.test_fspts_oidc_client.id}",
+          "client_id_prod_fspts_oidc_client" : "${aws_cognito_user_pool_client.prod_fspts_oidc_client.id}"
         },
         "target": "latest"
     },

--- a/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
@@ -1,0 +1,111 @@
+resource "aws_cognito_user_pool_client" "dev_fspts_oidc_client" {
+  access_token_validity                         = "5"
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = "true"
+  allowed_oauth_scopes                          = ["openid", "profile", "email"]
+  callback_urls                                 = [
+    var.oidc_sso_playground_url,
+    "http://localhost:3000",
+    "https://dlvrapps.nrs.gov.bc.ca/fspts"
+  ]
+  logout_urls                                   = [
+    var.oidc_sso_playground_url,
+    "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000",
+    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/fspts/logout"
+  ]
+  enable_propagate_additional_user_context_data = "false"
+  enable_token_revocation                       = "true"
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  id_token_validity                             = "60"
+  name                                          = "fspts_dev"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = var.minimum_oidc_attribute_list
+  refresh_token_validity                        = "24"
+  supported_identity_providers                  = [
+    "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
+    "${aws_cognito_identity_provider.dev_bceid_business_oidc_provider.provider_name}"
+  ]
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "hours"
+  }
+
+  user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
+  write_attributes = var.minimum_oidc_attribute_list
+}
+
+resource "aws_cognito_user_pool_client" "test_fspts_oidc_client" {
+  access_token_validity                         = "5"
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = "true"
+  allowed_oauth_scopes                          = ["openid", "profile", "email"]
+  callback_urls                                 = [
+    var.oidc_sso_playground_url,
+    "http://localhost:3000",
+    "https://testapps.nrs.gov.bc.ca/fspts"
+  ]
+  logout_urls                                   = [
+    var.oidc_sso_playground_url,
+    "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000",
+    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/fspts/logout"
+  ]
+  enable_propagate_additional_user_context_data = "false"
+  enable_token_revocation                       = "true"
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  id_token_validity                             = "60"
+  name                                          = "fspts_test"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = var.minimum_oidc_attribute_list
+  refresh_token_validity                        = "24"
+  supported_identity_providers                  = [
+    "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
+    "${aws_cognito_identity_provider.test_bceid_business_oidc_provider.provider_name}"
+  ]
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "hours"
+  }
+
+  user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
+  write_attributes = var.minimum_oidc_attribute_list
+}
+
+resource "aws_cognito_user_pool_client" "prod_fspts_oidc_client" {
+  access_token_validity                         = "5"
+  allowed_oauth_flows                           = ["code"]
+  allowed_oauth_flows_user_pool_client          = "true"
+  allowed_oauth_scopes                          = ["openid", "profile", "email"]
+  callback_urls                                 = [
+    var.oidc_sso_playground_url,
+    "https://apps.nrs.gov.bc.ca/fspts"
+  ]
+  logout_urls                                   = [
+    var.oidc_sso_playground_url,
+    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/fspts/logout"
+  ]
+  enable_propagate_additional_user_context_data = "false"
+  enable_token_revocation                       = "true"
+  explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  id_token_validity                             = "60"
+  name                                          = "fspts_prod"
+  prevent_user_existence_errors                 = "ENABLED"
+  read_attributes                               = var.minimum_oidc_attribute_list
+  refresh_token_validity                        = "24"
+  supported_identity_providers                  = [
+    "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
+    "${aws_cognito_identity_provider.prod_bceid_business_oidc_provider.provider_name}"
+  ]
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "hours"
+  }
+
+  user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
+  write_attributes = var.minimum_oidc_attribute_list
+}

--- a/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
@@ -16,11 +16,11 @@ resource "aws_cognito_user_pool_client" "dev_fspts_oidc_client" {
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "fspts_dev"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
+  refresh_token_validity                        = "30"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.dev_bceid_business_oidc_provider.provider_name}"
@@ -29,7 +29,7 @@ resource "aws_cognito_user_pool_client" "dev_fspts_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
@@ -54,11 +54,11 @@ resource "aws_cognito_user_pool_client" "test_fspts_oidc_client" {
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "fspts_test"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
+  refresh_token_validity                        = "30"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.test_bceid_business_oidc_provider.provider_name}"
@@ -67,7 +67,7 @@ resource "aws_cognito_user_pool_client" "test_fspts_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
@@ -90,11 +90,11 @@ resource "aws_cognito_user_pool_client" "prod_fspts_oidc_client" {
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "fspts_prod"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
+  refresh_token_validity                        = "30"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.prod_bceid_business_oidc_provider.provider_name}"
@@ -103,7 +103,7 @@ resource "aws_cognito_user_pool_client" "prod_fspts_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id

--- a/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
@@ -6,12 +6,12 @@ resource "aws_cognito_user_pool_client" "dev_fspts_oidc_client" {
   callback_urls                                 = [
     var.oidc_sso_playground_url,
     "http://localhost:3000",
-    "https://dlvrapps.nrs.gov.bc.ca/fspts"
+    "https://fspts-dev.apps.silver.devops.gov.bc.ca"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000",
-    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/fspts/logout"
+    "${var.cognito_app_client_logout_chain_url.dev}https://fspts-dev.apps.silver.devops.gov.bc.ca/logout"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
@@ -44,12 +44,12 @@ resource "aws_cognito_user_pool_client" "test_fspts_oidc_client" {
   callback_urls                                 = [
     var.oidc_sso_playground_url,
     "http://localhost:3000",
-    "https://testapps.nrs.gov.bc.ca/fspts"
+    "https://fspts-test.apps.silver.devops.gov.bc.ca"
   ]
   logout_urls                                   = [
     var.oidc_sso_playground_url,
     "${var.cognito_app_client_logout_chain_url.test}http://localhost:3000",
-    "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/fspts/logout"
+    "${var.cognito_app_client_logout_chain_url.test}https://fspts-test.apps.silver.devops.gov.bc.ca/logout"
   ]
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"

--- a/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_fspts.tf
@@ -20,7 +20,7 @@ resource "aws_cognito_user_pool_client" "dev_fspts_oidc_client" {
   name                                          = "fspts_dev"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "30"
+  refresh_token_validity                        = "60"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.dev_bceid_business_oidc_provider.provider_name}"
@@ -58,7 +58,7 @@ resource "aws_cognito_user_pool_client" "test_fspts_oidc_client" {
   name                                          = "fspts_test"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "30"
+  refresh_token_validity                        = "60"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.test_bceid_business_oidc_provider.provider_name}"
@@ -94,7 +94,7 @@ resource "aws_cognito_user_pool_client" "prod_fspts_oidc_client" {
   name                                          = "fspts_prod"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "30"
+  refresh_token_validity                        = "60"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.prod_bceid_business_oidc_provider.provider_name}"

--- a/server/flyway/sql/V80__add_fspts_app_and_roles.sql
+++ b/server/flyway/sql/V80__add_fspts_app_and_roles.sql
@@ -1,0 +1,82 @@
+-- Add FSPTS application and roles
+
+-- Add FSPTS_DEV, FSPTS_TEST and FSPTS_PROD applications
+INSERT INTO app_fam.fam_application (
+    application_name,
+    application_description,
+    app_environment,
+    create_user,
+    create_date
+)
+VALUES ('FSPTS_DEV', 'Forest Stewardship Plan Tracking System (DEV)', 'DEV', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_TEST', 'Forest Stewardship Plan Tracking System (TEST)', 'TEST', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_PROD', 'Forest Stewardship Plan Tracking System (PROD)', 'PROD', CURRENT_USER, CURRENT_DATE)
+;
+
+-- Add roles for FSPTS_DEV
+-- Concrete ('C') roles are IDIR-based, assigned directly to a user.
+-- Abstract ('A') roles are BCeID-based, scoped to a forest client (delegated access).
+INSERT INTO app_fam.fam_role (
+    role_name,
+    display_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization, scoped to a forest client.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE)
+;
+
+-- Add roles for FSPTS_TEST
+INSERT INTO app_fam.fam_role (
+    role_name,
+    display_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization, scoped to a forest client.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE)
+;
+
+-- Add roles for FSPTS_PROD
+INSERT INTO app_fam.fam_role (
+    role_name,
+    display_name,
+    role_purpose,
+    application_id,
+    role_type_code,
+    create_user,
+    create_date
+)
+VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization, scoped to a forest client.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE)
+;
+
+-- Create dev, test and prod Cognito app clients for FSPTS
+INSERT INTO app_fam.fam_application_client (
+    cognito_client_id,
+    application_id,
+    create_user,
+    create_date
+)
+VALUES ('${client_id_dev_fspts_oidc_client}', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), CURRENT_USER, CURRENT_DATE),
+       ('${client_id_test_fspts_oidc_client}', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), CURRENT_USER, CURRENT_DATE),
+       ('${client_id_prod_fspts_oidc_client}', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), CURRENT_USER, CURRENT_DATE)
+;

--- a/server/flyway/sql/V80__add_fspts_app_and_roles.sql
+++ b/server/flyway/sql/V80__add_fspts_app_and_roles.sql
@@ -14,8 +14,6 @@ VALUES ('FSPTS_DEV', 'Forest Stewardship Plan Tracking System (DEV)', 'DEV', CUR
 ;
 
 -- Add roles for FSPTS_DEV
--- Concrete ('C') roles are IDIR-based, assigned directly to a user.
--- Abstract ('A') roles are BCeID-based, scoped to a forest client (delegated access).
 INSERT INTO app_fam.fam_role (
     role_name,
     display_name,
@@ -30,7 +28,7 @@ VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view F
        ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization, scoped to a forest client.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE)
+       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE)
 ;
 
 -- Add roles for FSPTS_TEST
@@ -48,7 +46,7 @@ VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view F
        ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization, scoped to a forest client.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE)
+       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE)
 ;
 
 -- Add roles for FSPTS_PROD
@@ -66,7 +64,7 @@ VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view F
        ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization, scoped to a forest client.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE)
+       ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE)
 ;
 
 -- Create dev, test and prod Cognito app clients for FSPTS

--- a/server/flyway/sql/V80__add_fspts_app_and_roles.sql
+++ b/server/flyway/sql/V80__add_fspts_app_and_roles.sql
@@ -1,4 +1,6 @@
 -- Add FSPTS application and roles
+-- FSPTS: (= FSP legacy app)
+-- FSPTS: all roles are abstract roles (will be associated with forest clients)
 
 -- Add FSPTS_DEV, FSPTS_TEST and FSPTS_PROD applications
 INSERT INTO app_fam.fam_application (
@@ -23,10 +25,10 @@ INSERT INTO app_fam.fam_role (
     create_user,
     create_date
 )
-VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'C', CURRENT_USER, CURRENT_DATE),
+VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_DEV'), 'A', CURRENT_USER, CURRENT_DATE)
 ;
@@ -41,10 +43,10 @@ INSERT INTO app_fam.fam_role (
     create_user,
     create_date
 )
-VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'C', CURRENT_USER, CURRENT_DATE),
+VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_TEST'), 'A', CURRENT_USER, CURRENT_DATE)
 ;
@@ -59,10 +61,10 @@ INSERT INTO app_fam.fam_role (
     create_user,
     create_date
 )
-VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
-       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'C', CURRENT_USER, CURRENT_DATE),
+VALUES ('FSPTS_ADMINISTRATOR', 'Administrator', 'Add, change, delete, and view FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_DECISION_MAKER', 'Decision Maker', 'Approve FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_REVIEWER', 'Reviewer', 'Review FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
+       ('FSPTS_VIEW_ALL', 'View All', 'View all approved FSPs.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_SUBMITTER', 'Submitter', 'Submit FSPs, amendments, and extensions.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE),
        ('FSPTS_VIEW_ONLY', 'View Only', 'View approved FSPs submitted by organization.', (select application_id from app_fam.fam_application where application_name = 'FSPTS_PROD'), 'A', CURRENT_USER, CURRENT_DATE)
 ;


### PR DESCRIPTION
ref: #2140 2140

This PR onboard the Forest Stewardship Plan Tracking System (**FSPTS**) as a new application in FAM, covering infrastructure and configuration changes.

---

## **Infrastructure (Terraform)**
- **New OIDC Clients:**  
  Adds Cognito OIDC clients for FSPTS in **DEV**, **TEST**, and **PROD**  
  &rarr; oidc_clients_fspts.tf
- **Flyway Placeholders:**  
  Wires new FSPTS client IDs into Flyway migration payload  
  &rarr; flyway.tf

---

## **Configuration**
- **Docker & Workflow:**  
  Adds FSPTS Flyway placeholders to Docker and GitHub Actions workflow files for local and CI/CD migrations  
  &rarr; docker-base-services.yml  
  &rarr; reusable_data_model_gen.yml
- **Docker Compose:**  
  Defaults Postgres port to `5432` if not set  
  &rarr; docker-compose.yml

---

## **Database Migration (Flyway)**
- **New Application Records:**  
  Inserts `FSPTS_DEV`, `FSPTS_TEST`, and `FSPTS_PROD` into the application table.
- **Roles:**  
  Adds **six abstract roles** per environment:  
  `Administrator`, `Decision Maker`, `Reviewer`, `View All`, `Submitter`, `View Only`  
  &rarr; All with `role_type_code = 'A'`
- **App-Client Mapping:**  
  Links each environment to its Cognito client via placeholders  
  &rarr; V80__add_fspts_app_and_roles.sql

---
