### PR TITLE
fix: #2157 Refresh Token Validity and Set REPT Roles for call_api_flag

### DIFF
--- a/lza-infrastructure/terraform/server/oidc_clients_rept.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_rept.tf
@@ -28,11 +28,11 @@ resource "aws_cognito_user_pool_client" "dev_rept_oidc_client" {
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "rept_dev"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
+  refresh_token_validity                        = "60"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}"
   ]
@@ -40,7 +40,7 @@ resource "aws_cognito_user_pool_client" "dev_rept_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
@@ -71,11 +71,11 @@ resource "aws_cognito_user_pool_client" "test_rept_oidc_client" {
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "rept_test"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
+  refresh_token_validity                        = "60"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}"
   ]
@@ -83,7 +83,7 @@ resource "aws_cognito_user_pool_client" "test_rept_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
@@ -108,11 +108,11 @@ resource "aws_cognito_user_pool_client" "prod_rept_oidc_client" {
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "rept_prod"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
+  refresh_token_validity                        = "60"
   supported_identity_providers                  = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}"
   ]
@@ -120,7 +120,7 @@ resource "aws_cognito_user_pool_client" "prod_rept_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id

--- a/server/flyway/sql/V81__adjust_rept_roles_call_api_flag.sql
+++ b/server/flyway/sql/V81__adjust_rept_roles_call_api_flag.sql
@@ -1,0 +1,7 @@
+-- V81__adjust_rept_roles_call_api_flag.sql
+-- Set call_api_flag to true for REPT_ADMIN and REPT_VIEWER roles in the REPT application
+
+UPDATE app_fam.fam_role
+SET call_api_flag = true
+WHERE application_id in (select application_id from app_fam.fam_application where application_name IN ('REPT_DEV', 'REPT_TEST', 'REPT_PROD'))
+  AND role_name IN ('REPT_ADMIN', 'REPT_VIEWER');


### PR DESCRIPTION
Minor adjustment for REPT client below:

### Cognito Client [Terraform]
- Refresh token - 60 minutes
- ID token - 5 minutes

### Role Permission [Flyway]
- Both 'REPT_ADMIN' and REPT_VIEWER' roles will need call_api_flag = true