### PR TITLE
fix: remove lexis federal submitter role

### DIFF
--- a/server/flyway/sql/V91__remove_lexis_federal_submitter_role.sql
+++ b/server/flyway/sql/V91__remove_lexis_federal_submitter_role.sql
@@ -1,0 +1,8 @@
+-- Remove deprecated LEXIS federal submitter role.
+-- Federal submissions are authorized by a machine-to-machine Keycloak scope.
+
+DELETE FROM app_fam.fam_role fr
+USING app_fam.fam_application fa
+WHERE fa.application_id = fr.application_id
+  AND fa.application_name IN ('LEXIS_DEV', 'LEXIS_TEST', 'LEXIS_PROD')
+  AND fr.role_name = 'LEXIS_FEDERAL_SUBMITTER';


### PR DESCRIPTION
no one has been assigned the role, therefore should be safe