### PR TITLE
fix: configure ilcr callbacks for gold

### DIFF
--- a/lza-infrastructure/terraform/server/oidc_clients_ilcr.tf
+++ b/lza-infrastructure/terraform/server/oidc_clients_ilcr.tf
@@ -1,27 +1,48 @@
+locals {
+  ilcr_dev_host_urls = [
+    for i in range(var.dev_pr_url_count) : "https://nr-ilcr-${i}.apps.gold.devops.gov.bc.ca"
+  ]
+
+  ilcr_test_host_urls = [
+    "https://nr-ilcr-test.apps.gold.devops.gov.bc.ca"
+  ]
+
+  ilcr_prod_host_urls = [
+    "https://nr-ilcr-prod.apps.gold.devops.gov.bc.ca"
+  ]
+}
+
 resource "aws_cognito_user_pool_client" "dev_ilcr_oidc_client" {
-  access_token_validity                         = "5"
-  allowed_oauth_flows                           = ["code"]
-  allowed_oauth_flows_user_pool_client          = "true"
-  allowed_oauth_scopes                          = ["openid", "profile", "email"]
-  callback_urls                                 = [
-    var.oidc_sso_playground_url,
-    "http://localhost:8080/ilcr/callback",
-    "https://dlvrapps.nrs.gov.bc.ca/ext/ilcr/callback"
-  ]
-  logout_urls                                   = [
-    var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.dev}http://localhost:8080/ilcr/logout",
-    "${var.cognito_app_client_logout_chain_url.dev}https://dlvrapps.nrs.gov.bc.ca/ext/ilcr/logout"
-  ]
+  access_token_validity                = "5"
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_flows_user_pool_client = "true"
+  allowed_oauth_scopes                 = ["openid", "profile", "email"]
+  callback_urls = concat(
+    [
+      var.oidc_sso_playground_url,
+      "http://localhost:3000/"
+    ],
+    local.ilcr_dev_host_urls
+  )
+  logout_urls = concat(
+    [
+      var.oidc_sso_playground_url,
+      "${var.cognito_app_client_logout_chain_url.dev}http://localhost:3000/logout",
+    ],
+    [
+      for url in local.ilcr_dev_host_urls :
+      "${var.cognito_app_client_logout_chain_url.dev}${url}/logout"
+    ]
+  )
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "ilcr_dev"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
-  supported_identity_providers                  = [
+  refresh_token_validity                        = "60"
+  supported_identity_providers = [
     "${aws_cognito_identity_provider.dev_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.dev_bceid_business_oidc_provider.provider_name}"
   ]
@@ -29,7 +50,7 @@ resource "aws_cognito_user_pool_client" "dev_ilcr_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
@@ -37,29 +58,24 @@ resource "aws_cognito_user_pool_client" "dev_ilcr_oidc_client" {
 }
 
 resource "aws_cognito_user_pool_client" "test_ilcr_oidc_client" {
-  access_token_validity                         = "5"
-  allowed_oauth_flows                           = ["code"]
-  allowed_oauth_flows_user_pool_client          = "true"
-  allowed_oauth_scopes                          = ["openid", "profile", "email"]
-  callback_urls                                 = [
-      var.oidc_sso_playground_url,
-      "http://localhost:8080/ilcr/callback",
-      "https://testapps.nrs.gov.bc.ca/ext/ilcr/callback"
-    ]
-  logout_urls                                   = [
-      var.oidc_sso_playground_url,
-      "${var.cognito_app_client_logout_chain_url.test}http://localhost:8080/ilcr/logout",
-      "${var.cognito_app_client_logout_chain_url.test}https://testapps.nrs.gov.bc.ca/ext/ilcr/logout"
-    ]
+  access_token_validity                = "5"
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_flows_user_pool_client = "true"
+  allowed_oauth_scopes                 = ["openid", "profile", "email"]
+  callback_urls                        = concat([var.oidc_sso_playground_url], local.ilcr_test_host_urls)
+  logout_urls = concat(
+    [var.oidc_sso_playground_url],
+    [for url in local.ilcr_test_host_urls : "${var.cognito_app_client_logout_chain_url.test}${url}/logout"]
+  )
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "ilcr_test"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
-  supported_identity_providers                  = [
+  refresh_token_validity                        = "60"
+  supported_identity_providers = [
     "${aws_cognito_identity_provider.test_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.test_bceid_business_oidc_provider.provider_name}"
   ]
@@ -67,7 +83,7 @@ resource "aws_cognito_user_pool_client" "test_ilcr_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id
@@ -75,27 +91,24 @@ resource "aws_cognito_user_pool_client" "test_ilcr_oidc_client" {
 }
 
 resource "aws_cognito_user_pool_client" "prod_ilcr_oidc_client" {
-  access_token_validity                         = "5"
-  allowed_oauth_flows                           = ["code"]
-  allowed_oauth_flows_user_pool_client          = "true"
-  allowed_oauth_scopes                          = ["openid", "profile", "email"]
-  callback_urls                                 = [
-    var.oidc_sso_playground_url,
-    "https://apps.nrs.gov.bc.ca/ext/ilcr/callback"
-  ]
-  logout_urls                                   = [
-    var.oidc_sso_playground_url,
-    "${var.cognito_app_client_logout_chain_url.prod}https://apps.nrs.gov.bc.ca/ext/ilcr/logout"
-  ]
+  access_token_validity                = "5"
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_flows_user_pool_client = "true"
+  allowed_oauth_scopes                 = ["openid", "profile", "email"]
+  callback_urls                        = concat([var.oidc_sso_playground_url], local.ilcr_prod_host_urls)
+  logout_urls = concat(
+    [var.oidc_sso_playground_url],
+    [for url in local.ilcr_prod_host_urls : "${var.cognito_app_client_logout_chain_url.prod}${url}/logout"]
+  )
   enable_propagate_additional_user_context_data = "false"
   enable_token_revocation                       = "true"
   explicit_auth_flows                           = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  id_token_validity                             = "60"
+  id_token_validity                             = "5"
   name                                          = "ilcr_prod"
   prevent_user_existence_errors                 = "ENABLED"
   read_attributes                               = var.minimum_oidc_attribute_list
-  refresh_token_validity                        = "24"
-  supported_identity_providers                  = [
+  refresh_token_validity                        = "60"
+  supported_identity_providers = [
     "${aws_cognito_identity_provider.prod_idir_oidc_provider.provider_name}",
     "${aws_cognito_identity_provider.prod_bceid_business_oidc_provider.provider_name}"
   ]
@@ -103,7 +116,7 @@ resource "aws_cognito_user_pool_client" "prod_ilcr_oidc_client" {
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"
-    refresh_token = "hours"
+    refresh_token = "minutes"
   }
 
   user_pool_id     = aws_cognito_user_pool.fam_user_pool.id


### PR DESCRIPTION
## Summary

Rewrites `oidc_clients_ilcr.tf` to the same pattern as CSP (`oidc_clients_csp.tf`), in preparation for the ILCR rewrite deploying to the gold cluster.

- **Callback/logout URLs**: replaces the legacy `*.nrs.gov.bc.ca/ext/ilcr/callback` and `localhost:8080` URLs with gold-cluster hostnames:
  - dev: `https://nr-ilcr-{0..N}.apps.gold.devops.gov.bc.ca` generated via `var.dev_pr_url_count` (50 PR environment URLs, same as CSP) plus `localhost:3000` for local dev
  - test: `https://nr-ilcr-test.apps.gold.devops.gov.bc.ca`
  - prod: `https://nr-ilcr-prod.apps.gold.devops.gov.bc.ca`
- **Token validity aligned with CSP**: id token 60 min -> 5 min; refresh token 24 h -> 60 min (units `hours` -> `minutes`)
- No changes to identity providers (IDIR + BCeID Business), scopes, or auth flows

## Notes for reviewers

- The removed legacy callbacks belong to the cancelled legacy Java ILCR FAM integration, which never went live, so no active logins depend on them.
- The token validity change is behavioral (shorter sessions), intentionally matching the CSP standard.
- No secrets in the diff: all values are Terraform variable/resource references or public hostnames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)