### PR TITLE
fix: Bump up Aurora db minor engine version

### DIFF
--- a/lza-infrastructure/terraform/server/aurora-v2.tf
+++ b/lza-infrastructure/terraform/server/aurora-v2.tf
@@ -36,8 +36,8 @@ resource "aws_db_subnet_group" "famdb_subnet_group" {
 }
 
 data "aws_rds_engine_version" "postgresql" {
-  engine  = "aurora-postgresql"
-  version = "16.6"
+  engine             = "aurora-postgresql"
+  preferred_versions = ["16.9", "16.10", "16.11", "16.12", "16.13", "16.14"]
 }
 
 module "aurora_postgresql_v2" {


### PR DESCRIPTION
AWS retried PostgreSQL engine version 16.6 (FAM currently uses) and is no longer available.
This causes FAM pipeline Terraform plan to fail and surface the error.
The change is a minor version bump up, with list of versions available at 16.x family.
It will use the closest one available, in this case 16.9.